### PR TITLE
Distribute as tar.gz instead of tar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/distributions/structurizr-site-generatr-${{ github.ref_name }}.tar
-          asset_name: structurizr-site-generatr-${{ github.ref_name }}.tar
+          asset_path: ./build/distributions/structurizr-site-generatr-${{ github.ref_name }}.tar.gz
+          asset_name: structurizr-site-generatr-${{ github.ref_name }}.tar.gz
           asset_content_type: application/x-tar
       - uses: actions/upload-release-asset@v1.0.2
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,4 +61,9 @@ tasks {
             attributes["Implementation-Version"] = project.version
         }
     }
+
+    withType<Tar> {
+        archiveExtension.set("tar.gz")
+        compression = Compression.GZIP
+    }
 }


### PR DESCRIPTION
This way, Renovate will correctly update the Homebrew formula for this
repository.