### PR TITLE
Reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,2 @@
 *
 !build/install
-!*.kts
-!gradle*
-!src
-!entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM eclipse-temurin:18-jre
+FROM eclipse-temurin:18-jre-alpine
 
 USER root
-RUN apt-get update \
-    && apt-get install -y graphviz \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache graphviz
 RUN mkdir -p /var/model \
     && chown 65532:65532 /var/model
-RUN useradd -d /home/generatr -u 65532 --create-home generatr
+RUN adduser -h /home/generatr -u 65532 -D generatr
 
 ENTRYPOINT ["/opt/structurizr-site-generatr/bin/structurizr-site-generatr"]
 


### PR DESCRIPTION
Reduce the size of the Docker image, by using `eclipse-temurin:18-jre-alpine` as the base image, instead of `eclipse-temurin:18-jre`. The uncompressed size of the Docker image is now 314MB, down from 485MB.

Fixes #39.