### PR TITLE
Show documentation section on software systems home

### DIFF
--- a/docs/example/internet-banking-system/docs/0001-introduction.md
+++ b/docs/example/internet-banking-system/docs/0001-introduction.md
@@ -1,0 +1,11 @@
+# Description
+
+This is our fancy Internet Banking System.
+
+## Vision
+
+One system to rule them all!
+
+## References
+
+- Source Code on GitHub: [https://github.com/avisi-cloud/structurizr-site-generatr]

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -22,6 +22,7 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
             atm = softwaresystem "ATM" "Allows customers to withdraw cash." "Existing System"
 
             internetBankingSystem = softwaresystem "Internet Banking System" "Allows customers to view information about their bank accounts, and make payments." {
+                !docs internet-banking-system/docs
                 !adrs internet-banking-system/adr
 
                 singlePageApplication = container "Single-Page Application" "Provides all of the Internet banking functionality to customers via their web browser." "JavaScript and Angular" "Web Browser"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModel.kt
@@ -4,4 +4,10 @@ import com.structurizr.model.SoftwareSystem
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemHomePageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
-    SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.HOME)
+    SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.HOME) {
+    val content = softwareSystem.documentation.sections
+        .sortedBy { it.filename }
+        .firstOrNull()
+        ?.let { MarkdownViewModel(it.content) }
+        ?: MarkdownViewModel("# Description${System.lineSeparator()}${softwareSystem.description}")
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemHomePage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemHomePage.kt
@@ -1,13 +1,10 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
 import kotlinx.html.HTML
-import kotlinx.html.h1
-import kotlinx.html.p
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemHomePageViewModel
 
 fun HTML.softwareSystemHomePage(viewModel: SoftwareSystemHomePageViewModel) {
     softwareSystemPage(viewModel) {
-        h1 { +"Description" }
-        p { +viewModel.description }
+        markdown(viewModel, viewModel.content)
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModelTest.kt
@@ -2,6 +2,9 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import com.structurizr.documentation.Format
+import com.structurizr.documentation.Section
 import com.structurizr.model.SoftwareSystem
 import kotlin.test.Test
 
@@ -14,5 +17,33 @@ class SoftwareSystemHomePageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.tabs.single { it.link.active }.tab)
             .isEqualTo(SoftwareSystemPageViewModel.Tab.HOME)
+    }
+
+    @Test
+    fun `no section present`() {
+        val generatorContext = generatorContext()
+        val softwareSystem: SoftwareSystem = generatorContext.workspace.model.addSoftwareSystem("Software system")
+            .apply { description = "It's a system." }
+        val viewModel = SoftwareSystemHomePageViewModel(generatorContext, softwareSystem)
+
+        assertThat(viewModel.content)
+            .prop(MarkdownViewModel::markdown).isEqualTo(
+                "# Description${System.lineSeparator()}${softwareSystem.description}"
+            )
+    }
+
+    @Test
+    fun `section present`() {
+        val generatorContext = generatorContext()
+        val softwareSystem: SoftwareSystem = generatorContext.workspace.model.addSoftwareSystem("Software system")
+            .apply {
+                documentation.addSection(Section("Title", Format.Markdown, "# Content"))
+            }
+        val viewModel = SoftwareSystemHomePageViewModel(generatorContext, softwareSystem)
+
+        assertThat(viewModel.content)
+            .prop(MarkdownViewModel::markdown).isEqualTo(
+                softwareSystem.documentation.sections.single().content
+            )
     }
 }


### PR DESCRIPTION
Render the first found documentation section (sorted by filename) as home page for software systems. Other documentation section will be (for now) ignored. When no documentation is present, the presentation is the same as of now, just showing the description.

The example is extended with a doc.

In the long term, other documentation files could be rendered similar to ADRs, but that is another story.