### PR TITLE
Fix Gradle build error

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 19
+          java-version: 18
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Execute Gradle build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java temurin-19.0.0+36
+java temurin-18.0.2+101


### PR DESCRIPTION
The `Gradle build` action on GitHub fails with the following error:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not open cp_init generic class cache for initialization script '/home/runner/.gradle/init.d/build-result-capture.init.gradle' (/home/runner/.gradle/caches/7.5.1/scripts/1e64q25zpdl12rebgg3luboth).
> BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 63
```

See https://github.com/avisi-cloud/structurizr-site-generatr/actions/runs/3180082333/jobs/5183611488

Reverting back to using JDK 18 for building the project fixes this issue.