### PR TITLE
Target JVM v17 bytecode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ tasks {
     withType<KotlinCompile> {
         kotlinOptions {
             freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
-            jvmTarget = "18"
+            jvmTarget = "17"
         }
     }
 


### PR DESCRIPTION
JVM 18 features are no requirement for building the project, so targetting JVM 17 allows the project to compile (and run) on the current Java LTS release.