### PR TITLE
Revert to building the project using JDK 18

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 18
+          java-version: 19
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Execute Gradle build


### PR DESCRIPTION
Gradle doesn't support JDK 19 yet, which seems to be the cause of the build error. 

This mirrors https://github.com/avisi-cloud/structurizr-site-generatr/commit/bc857e9df623c741fad576a486d1afcb2061dfaf but now also for the release workflow.