### PR TITLE
add opencontainers image source label during docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: sign container image


### PR DESCRIPTION
Add [opencontainers image source](https://github.com/opencontainers/image-spec/blob/main/annotations.md) label during docker build. These labels are used by automation tooling to gather meta data about an OCI artifact. For example, Renovate will use it to detect where to find the release notes.