### PR TITLE
Remove PEC reference from generated index.html

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -29,7 +29,7 @@ fun generateRedirectingIndexPage(exportDir: File, defaultBranch: String) {
                         httpEquiv = "refresh"
                         content = "0; url=$defaultBranch/"
                     }
-                    title { +"PEC Architectuur" }
+                    title { +"Structurizr site generatr" }
                 }
                 body()
             }


### PR DESCRIPTION
There was an outdated reference to an original SoftwareSystem in the code still somewhere. This is not visible to the end users since they are usually redirected instantly from this page but still visible in the generated source.