### PR TITLE
Add support for software system properties

### DIFF
--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -14,8 +14,16 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
         acquirer = softwaresystem "Acquirer" "Facilitates PIN transactions for merchants."
 
         enterprise "Big Bank plc" {
-            supportStaff = person "Customer Service Staff" "Customer service staff within the bank." "Bank Staff"
-            backoffice = person "Back Office Staff" "Administration and support staff within the bank." "Bank Staff"
+            supportStaff = person "Customer Service Staff" "Customer service staff within the bank." "Bank Staff" {
+                properties {
+                    "Location" "Customer Services"
+                }
+            }
+            backoffice = person "Back Office Staff" "Administration and support staff within the bank." "Bank Staff" {
+                properties {
+                    "Location" "Internal Services"
+                }
+            }
 
             mainframe = softwaresystem "Mainframe Banking System" "Stores all of the core banking information about customers, accounts, transactions, etc." "Existing System"
             email = softwaresystem "E-mail System" "The internal Microsoft Exchange e-mail system." "Existing System"
@@ -24,6 +32,10 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
             internetBankingSystem = softwaresystem "Internet Banking System" "Allows customers to view information about their bank accounts, and make payments." {
                 !docs internet-banking-system/docs
                 !adrs internet-banking-system/adr
+                properties {
+                    "Owner" "Customer Services"
+                    "Development Team" "Dev/Internet Services"
+                }
 
                 singlePageApplication = container "Single-Page Application" "Provides all of the Internet banking functionality to customers via their web browser." "JavaScript and Angular" "Web Browser"
                 mobileApp = container "Mobile App" "Provides a limited subset of the Internet banking functionality to customers via their mobile device." "Xamarin" "Mobile App"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/CreateStructurizrWorkspace.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/CreateStructurizrWorkspace.kt
@@ -1,0 +1,15 @@
+package nl.avisi.structurizr.site.generatr
+
+import com.structurizr.dsl.StructurizrDslParser
+import com.structurizr.export.plantuml.C4PlantUMLExporter
+import com.structurizr.model.Element
+import java.io.File
+
+fun createStructurizrWorkspace(workspaceFile: File) =
+    StructurizrDslParser()
+        .apply { parse(workspaceFile) }
+        .workspace
+        .apply {
+            views.configuration.addProperty(C4PlantUMLExporter.C4PLANTUML_ELEMENT_PROPERTIES_PROPERTY, true.toString())
+        }
+        ?: throw IllegalStateException("Workspace could not be parsed")

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -80,7 +80,7 @@ class GenerateSiteCommand : Subcommand(
             println("Generating site for branch $branch")
             clonedRepository.checkoutBranch(branch)
 
-            val workspace = parseStructurizrDslWorkspace(workspaceFileInRepo)
+            val workspace = createStructurizrWorkspace(workspaceFileInRepo)
             generateDiagrams(workspace, File(siteDir, branch))
             generateSite(
                 version,
@@ -94,7 +94,7 @@ class GenerateSiteCommand : Subcommand(
     }
 
     private fun generateSiteForModel(siteDir: File) {
-        val workspace = parseStructurizrDslWorkspace(File(workspaceFile))
+        val workspace = createStructurizrWorkspace(File(workspaceFile))
         generateDiagrams(workspace, File(siteDir, defaultBranch))
         generateSite(
             version,

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -47,7 +47,7 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
     }
 
     private fun updateSite() {
-        val workspace = parseStructurizrDslWorkspace(File(workspaceFile))
+        val workspace = createStructurizrWorkspace(File(workspaceFile))
         val exportDir = File(siteDir, "master")
 
         println("Generating diagrams...")

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
@@ -1,16 +1,8 @@
 package nl.avisi.structurizr.site.generatr
 
-import com.structurizr.dsl.StructurizrDslParser
 import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
-import java.io.File
-
-fun parseStructurizrDslWorkspace(workspaceFile: File) =
-    StructurizrDslParser()
-        .apply { parse(workspaceFile) }
-        .workspace
-        ?: throw IllegalStateException("Workspace could not be parsed")
 
 val Model.includedSoftwareSystems: List<SoftwareSystem>
     get() = softwareSystems.filter { it.location != Location.External }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ExternalLinkViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ExternalLinkViewModel.kt
@@ -1,0 +1,6 @@
+package nl.avisi.structurizr.site.generatr.site.model
+
+data class ExternalLinkViewModel(
+    val title: String,
+    val href: String,
+)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PropertiesTableViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PropertiesTableViewModel.kt
@@ -7,13 +7,13 @@ fun createPropertiesTableViewModel(properties: Map<String, String>) =
         headerRow(headerCell("Name"), headerCell("Value"))
         properties
             .toSortedMap()
-            .forEach {
+            .forEach { (name, value) ->
                 bodyRow(
-                    cell(it.key),
-                    if (Url.isUrl(it.value))
-                        cellWithExternalLink(it.value, it.value)
+                    cell(name),
+                    if (Url.isUrl(value))
+                        cellWithExternalLink(value, value)
                     else
-                        cell(it.value)
+                        cell(value)
                 )
             }
     }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PropertiesTableViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PropertiesTableViewModel.kt
@@ -1,0 +1,19 @@
+package nl.avisi.structurizr.site.generatr.site.model
+
+import com.structurizr.util.Url
+
+fun createPropertiesTableViewModel(properties: Map<String, String>) =
+    TableViewModel.create {
+        headerRow(headerCell("Name"), headerCell("Value"))
+        properties
+            .toSortedMap()
+            .forEach {
+                bodyRow(
+                    cell(it.key),
+                    if (Url.isUrl(it.value))
+                        cellWithExternalLink(it.value, it.value)
+                    else
+                        cell(it.value)
+                )
+            }
+    }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModel.kt
@@ -5,6 +5,8 @@ import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemHomePageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
     SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.HOME) {
+    val hasProperties = softwareSystem.properties.any()
+    val propertiesTable = createPropertiesTableViewModel(softwareSystem.properties)
     val content = softwareSystem.documentation.sections
         .minByOrNull { it.order }
         ?.let { MarkdownViewModel(it.content) }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/TableViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/TableViewModel.kt
@@ -22,6 +22,13 @@ data class TableViewModel(val headerRows: List<RowViewModel>, val bodyRows: List
         override fun toString() = if (isHeader) "headerCell($link)" else "cell($link)"
     }
 
+    data class ExternalLinkCellViewModel(
+        val link: ExternalLinkViewModel,
+        override val isHeader: Boolean
+    ) : CellViewModel {
+        override fun toString() = if (isHeader) "headerCell($link)" else "cell($link)"
+    }
+
     data class RowViewModel(val columns: List<CellViewModel>) {
         override fun toString() =
             columns.joinToString(separator = ", ", prefix = "row { ", postfix = " }") { it.toString() }
@@ -49,6 +56,9 @@ data class TableViewModel(val headerRows: List<RowViewModel>, val bodyRows: List
 
         fun cellWithLink(pageViewModel: PageViewModel, title: String, href: String) =
             LinkCellViewModel(LinkViewModel(pageViewModel, title, href), false)
+
+        fun cellWithExternalLink(title: String, href: String) =
+            ExternalLinkCellViewModel(ExternalLinkViewModel(title, href), false)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/ExternalLink.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/ExternalLink.kt
@@ -1,0 +1,14 @@
+package nl.avisi.structurizr.site.generatr.site.views
+
+import kotlinx.html.FlowOrPhrasingContent
+import kotlinx.html.a
+import nl.avisi.structurizr.site.generatr.site.model.ExternalLinkViewModel
+import nl.avisi.structurizr.site.generatr.site.model.LinkViewModel
+
+fun FlowOrPhrasingContent.externalLink(viewModel: ExternalLinkViewModel) {
+    a(
+        href = viewModel.href,
+    ) {
+        +viewModel.title
+    }
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemHomePage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemHomePage.kt
@@ -1,10 +1,15 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
 import kotlinx.html.HTML
+import kotlinx.html.h2
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemHomePageViewModel
 
 fun HTML.softwareSystemHomePage(viewModel: SoftwareSystemHomePageViewModel) {
     softwareSystemPage(viewModel) {
         markdown(viewModel, viewModel.content)
+        if (viewModel.hasProperties) {
+            h2 { +"Properties" }
+            table(viewModel.propertiesTable)
+        }
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Table.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Table.kt
@@ -54,5 +54,10 @@ private fun TR.cell(viewModel: TableViewModel.CellViewModel) {
                 th { link(viewModel.link) }
             else
                 td { link(viewModel.link) }
+        is TableViewModel.ExternalLinkCellViewModel ->
+            if (viewModel.isHeader)
+                th { externalLink(viewModel.link) }
+            else
+                td { externalLink(viewModel.link) }
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/PropertiesTableViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/PropertiesTableViewModelTest.kt
@@ -1,0 +1,61 @@
+package nl.avisi.structurizr.site.generatr.site.model
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class PropertiesTableViewModelTest : ViewModelTest() {
+
+    @Test
+    fun `no properties available`() {
+        assertThat(createPropertiesTableViewModel(emptyMap()))
+            .isEqualTo(
+                TableViewModel.create {
+                    propertiesTableHeaderRow()
+                }
+            )
+    }
+
+    @Test
+    fun `many properties sorted by key`() {
+        val properties = mapOf(
+            "b name" to "value",
+            "a name" to "value"
+        )
+
+        assertThat(createPropertiesTableViewModel(properties)).isEqualTo(
+            TableViewModel.create {
+                propertiesTableHeaderRow()
+                bodyRow(
+                    cell("a name"),
+                    cell("value"),
+                )
+                bodyRow(
+                    cell("b name"),
+                    cell("value"),
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `properties with link`() {
+        val properties = mapOf(
+            "url" to "https://tempuri.org/",
+        )
+
+        assertThat(createPropertiesTableViewModel(properties)).isEqualTo(
+            TableViewModel.create {
+                propertiesTableHeaderRow()
+                bodyRow(
+                    cell("url"),
+                    cellWithExternalLink("https://tempuri.org/", "https://tempuri.org/"),
+                )
+            }
+        )
+    }
+
+    private fun TableViewModel.TableViewInitializerContext.propertiesTableHeaderRow() {
+        headerRow(headerCell("Name"), headerCell("Value"))
+    }
+}

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
@@ -101,6 +101,7 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
                     when (val source = it.columns[0]) {
                         is TableViewModel.TextCellViewModel -> source.title
                         is TableViewModel.LinkCellViewModel -> source.link.title
+                        is TableViewModel.ExternalLinkCellViewModel -> source.link.title
                     }
                 }
         ).containsExactly(

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModelTest.kt
@@ -1,5 +1,6 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.prop
@@ -45,5 +46,38 @@ class SoftwareSystemHomePageViewModelTest : ViewModelTest() {
             .prop(MarkdownViewModel::markdown).isEqualTo(
                 softwareSystem.documentation.sections.single().content
             )
+    }
+
+    @Test
+    fun `no properties present`() {
+        val generatorContext = generatorContext()
+        val softwareSystem: SoftwareSystem = generatorContext.workspace.model.addSoftwareSystem("Software system")
+            .apply { description = "It's a system." }
+        val viewModel = SoftwareSystemHomePageViewModel(generatorContext, softwareSystem)
+
+        assertThat(viewModel)
+            .all {
+                prop(SoftwareSystemHomePageViewModel::hasProperties).isEqualTo(false)
+                prop(SoftwareSystemHomePageViewModel::propertiesTable)
+                    .isEqualTo(createPropertiesTableViewModel(mapOf()))
+            }
+    }
+
+    @Test
+    fun `properties present`() {
+        val generatorContext = generatorContext()
+        val softwareSystem: SoftwareSystem = generatorContext.workspace.model.addSoftwareSystem("Software system")
+            .apply {
+                description = "It's a system."
+                addProperty("Url", "https://tempuri.org/")
+            }
+        val viewModel = SoftwareSystemHomePageViewModel(generatorContext, softwareSystem)
+
+        assertThat(viewModel)
+            .all {
+                prop(SoftwareSystemHomePageViewModel::hasProperties).isEqualTo(true)
+                prop(SoftwareSystemHomePageViewModel::propertiesTable)
+                    .isEqualTo(createPropertiesTableViewModel(softwareSystem.properties))
+            }
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/TableViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/TableViewModelTest.kt
@@ -96,6 +96,24 @@ class TableViewModelTest : ViewModelTest() {
     }
 
     @Test
+    fun `cell with external link`() {
+        val viewModel = TableViewModel.create {
+            bodyRow(cellWithExternalLink("Temporary URI", "https://tempuri.org/"))
+        }
+
+        assertThat(viewModel.bodyRows).containsAll(
+            TableViewModel.RowViewModel(
+                listOf(
+                    TableViewModel.ExternalLinkCellViewModel(
+                        ExternalLinkViewModel("Temporary URI", "https://tempuri.org/"),
+                        isHeader = false
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
     fun `cell with index`() {
         val viewModel = TableViewModel.create {
             bodyRow(cellWithIndex("1"))


### PR DESCRIPTION
Show properties as table on the software systems home page and in the generated diagrams.
Properties containing an URL will be rendered as simple link on the software systems home.

The generated diagrams will also show properties on other elements, e.g. persons.