### PR TITLE
Make diagram elements clickable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("net.sourceforge.plantuml:plantuml:1.2022.12")
 
     implementation("com.vladsch.flexmark:flexmark-all:0.64.0")
+    implementation("org.jsoup:jsoup:1.15.3")
 
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.8.0")
 

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -36,6 +36,7 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
                     "Owner" "Customer Services"
                     "Development Team" "Dev/Internet Services"
                 }
+                url https://en.wikipedia.org/wiki/Online_banking
 
                 singlePageApplication = container "Single-Page Application" "Provides all of the Internet banking functionality to customers via their web browser." "JavaScript and Angular" "Web Browser"
                 mobileApp = container "Mobile App" "Provides a limited subset of the Internet banking functionality to customers via their mobile device." "Xamarin" "Mobile App"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/CreateStructurizrWorkspace.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/CreateStructurizrWorkspace.kt
@@ -11,5 +11,15 @@ fun createStructurizrWorkspace(workspaceFile: File) =
         .workspace
         .apply {
             views.configuration.addProperty(C4PlantUMLExporter.C4PLANTUML_ELEMENT_PROPERTIES_PROPERTY, true.toString())
+            model.elements.forEach {
+                moveUrlToProperty(it) // We need the URL later for our own links, preserve the original in a property
+            }
         }
         ?: throw IllegalStateException("Workspace could not be parsed")
+
+private fun moveUrlToProperty(element: Element) {
+    if (element.url != null) {
+        element.addProperty("Url", element.url)
+        element.url = null
+    }
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -81,7 +81,7 @@ class GenerateSiteCommand : Subcommand(
             clonedRepository.checkoutBranch(branch)
 
             val workspace = createStructurizrWorkspace(workspaceFileInRepo)
-            generateDiagrams(workspace, File(siteDir, branch))
+            generateDiagrams(workspace, File(siteDir, branch), branch)
             generateSite(
                 version,
                 workspace,
@@ -95,7 +95,7 @@ class GenerateSiteCommand : Subcommand(
 
     private fun generateSiteForModel(siteDir: File) {
         val workspace = createStructurizrWorkspace(File(workspaceFile))
-        generateDiagrams(workspace, File(siteDir, defaultBranch))
+        generateDiagrams(workspace, File(siteDir, defaultBranch), defaultBranch)
         generateSite(
             version,
             workspace,

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -48,21 +48,22 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
 
     private fun updateSite() {
         val workspace = createStructurizrWorkspace(File(workspaceFile))
-        val exportDir = File(siteDir, "master")
+        val branch = "master"
+        val exportDir = File(siteDir, branch)
 
         println("Generating diagrams...")
-        generateDiagrams(workspace, exportDir)
+        generateDiagrams(workspace, exportDir, branch)
 
         println("Generating site...")
         copySiteWideAssets(File(siteDir))
-        generateRedirectingIndexPage(File(siteDir), "master")
+        generateRedirectingIndexPage(File(siteDir), branch)
         generateSite(
             "0.0.0",
             workspace,
             assetsDir?.let { File(it) },
             File(siteDir),
-            listOf("master"),
-            "master"
+            listOf(branch),
+            branch
         )
 
         println("Successfully generated diagrams and site")

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
@@ -1,0 +1,51 @@
+package nl.avisi.structurizr.site.generatr.site
+
+import com.structurizr.Workspace
+import com.structurizr.export.IndentingWriter
+import com.structurizr.export.plantuml.C4PlantUMLExporter
+import com.structurizr.model.Element
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.View
+import nl.avisi.structurizr.site.generatr.includedSoftwareSystems
+import nl.avisi.structurizr.site.generatr.normalize
+
+class C4PlantUmlExporterWithElementLinks(
+    private val workspace: Workspace,
+    private val branch: String
+): C4PlantUMLExporter() {
+    companion object {
+        const val TEMP_URI = "https://will-be-changed-to-relative"
+    }
+
+    override fun writeElement(view: View?, element: Element?, writer: IndentingWriter?) {
+        if (element !is SoftwareSystem || !element.linkNeeded(view))
+            return super.writeElement(view, element, writer)
+
+        setElementUrl(element)
+        writeModifiedElement(view, element, writer)
+        restoreElement(element)
+    }
+
+    private fun Element.linkNeeded(view: View?) =
+        workspace.model.includedSoftwareSystems.contains(this) && this != view?.softwareSystem
+
+    private fun setElementUrl(element: Element) {
+        element.url = "${TEMP_URI}/$branch/${element.name.normalize()}/context/"
+    }
+
+    private fun writeModifiedElement(
+        view: View?,
+        element: Element?,
+        writer: IndentingWriter?
+    ) = IndentingWriter().let {
+        super.writeElement(view, element, it)
+        it.toString()
+            .replace(TEMP_URI, "")
+            .split(System.lineSeparator())
+            .forEach { line -> writer?.writeLine(line) }
+    }
+
+    private fun restoreElement(element: Element) {
+        element.url = null
+    }
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
@@ -2,7 +2,6 @@ package nl.avisi.structurizr.site.generatr.site
 
 import com.structurizr.Workspace
 import com.structurizr.export.Diagram
-import com.structurizr.export.plantuml.C4PlantUMLExporter
 import com.structurizr.export.plantuml.PlantUMLDiagram
 import net.sourceforge.plantuml.FileFormat
 import net.sourceforge.plantuml.FileFormatOption
@@ -10,12 +9,12 @@ import net.sourceforge.plantuml.SourceStringReader
 import java.io.File
 import java.net.URL
 
-fun generateDiagrams(workspace: Workspace, exportDir: File) {
+fun generateDiagrams(workspace: Workspace, exportDir: File, branch: String) {
     val pumlDir = File(exportDir, "puml").apply { mkdirs() }
     val pngDir = File(exportDir, "png").apply { mkdirs() }
     val svgDir = File(exportDir, "svg").apply { mkdirs() }
 
-    val plantUMLDiagrams = generatePlantUMLDiagrams(workspace)
+    val plantUMLDiagrams = generatePlantUMLDiagrams(workspace, branch)
 
     plantUMLDiagrams.parallelStream()
         .forEach { diagram ->
@@ -30,8 +29,8 @@ fun generateDiagrams(workspace: Workspace, exportDir: File) {
         }
 }
 
-private fun generatePlantUMLDiagrams(workspace: Workspace): Collection<Diagram> {
-    val plantUMLExporter = C4PlantUMLExporter()
+private fun generatePlantUMLDiagrams(workspace: Workspace, branch: String): Collection<Diagram> {
+    val plantUMLExporter = C4PlantUmlExporterWithElementLinks(workspace, branch)
 
     return plantUMLExporter.export(workspace)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/GeneratorContext.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/GeneratorContext.kt
@@ -1,10 +1,12 @@
 package nl.avisi.structurizr.site.generatr.site
 
 import com.structurizr.Workspace
+import java.io.File
 
 data class GeneratorContext(
     val version: String,
     val workspace: Workspace,
+    val exportDir: File,
     val branches: List<String>,
     val currentBranch: String
 )

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/GeneratorContext.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/GeneratorContext.kt
@@ -1,12 +1,11 @@
 package nl.avisi.structurizr.site.generatr.site
 
 import com.structurizr.Workspace
-import java.io.File
 
 data class GeneratorContext(
     val version: String,
     val workspace: Workspace,
-    val exportDir: File,
     val branches: List<String>,
-    val currentBranch: String
+    val currentBranch: String,
+    val svgFactory: (name: String) -> String
 )

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -45,7 +45,7 @@ fun generateSite(
     branches: List<String>,
     currentBranch: String
 ) {
-    val generatorContext = GeneratorContext(version, workspace, branches, currentBranch)
+    val generatorContext = GeneratorContext(version, workspace, exportDir, branches, currentBranch)
 
     if (assetsDir != null) copyAssets(assetsDir, exportDir)
     generateHtmlFiles(generatorContext, exportDir)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -45,7 +45,13 @@ fun generateSite(
     branches: List<String>,
     currentBranch: String
 ) {
-    val generatorContext = GeneratorContext(version, workspace, exportDir, branches, currentBranch)
+    val generatorContext = GeneratorContext(version, workspace, branches, currentBranch) {
+        val pathname = "${exportDir.absolutePath}/${currentBranch}/svg/${it}.svg"
+        File(pathname)
+            .let { file ->
+                if (file.exists()) file.readText() else "$pathname not found"
+            }
+    }
 
     if (assetsDir != null) copyAssets(assetsDir, exportDir)
     generateHtmlFiles(generatorContext, exportDir)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
@@ -1,8 +1,6 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.view.View
-import nl.avisi.structurizr.site.generatr.site.GeneratorContext
-import java.io.File
 
 data class DiagramViewModel(
     val name: String,
@@ -12,18 +10,12 @@ data class DiagramViewModel(
     val pumlLocation: ImageViewModel
 ) {
     companion object {
-        fun forView(pageViewModel: PageViewModel, view: View) = DiagramViewModel(
+        fun forView(pageViewModel: PageViewModel, view: View, svgFactory: (name: String) -> String) = DiagramViewModel(
             view.name,
-            File(svgPathname(pageViewModel.generatorContext, view))
-                .let {
-                    if (it.exists()) it.readText() else "<svg></svg>"
-                },
+            svgFactory(view.key),
             ImageViewModel(pageViewModel, "/svg/${view.key}.svg"),
             ImageViewModel(pageViewModel, "/png/${view.key}.png"),
             ImageViewModel(pageViewModel, "/puml/${view.key}.puml")
         )
-
-        private fun svgPathname(generatorContext: GeneratorContext, view: View) =
-            "${generatorContext.exportDir.absolutePath}/${generatorContext.currentBranch}/svg/${view.key}.svg"
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
@@ -1,9 +1,12 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.view.View
+import nl.avisi.structurizr.site.generatr.site.GeneratorContext
+import java.io.File
 
 data class DiagramViewModel(
     val name: String,
+    val svg: String,
     val svgLocation: ImageViewModel,
     val pngLocation: ImageViewModel,
     val pumlLocation: ImageViewModel
@@ -11,9 +14,16 @@ data class DiagramViewModel(
     companion object {
         fun forView(pageViewModel: PageViewModel, view: View) = DiagramViewModel(
             view.name,
+            File(svgPathname(pageViewModel.generatorContext, view))
+                .let {
+                    if (it.exists()) it.readText() else "<svg></svg>"
+                },
             ImageViewModel(pageViewModel, "/svg/${view.key}.svg"),
             ImageViewModel(pageViewModel, "/png/${view.key}.png"),
             ImageViewModel(pageViewModel, "/puml/${view.key}.puml")
         )
+
+        private fun svgPathname(generatorContext: GeneratorContext, view: View) =
+            "${generatorContext.exportDir.absolutePath}/${generatorContext.currentBranch}/svg/${view.key}.svg"
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModel.kt
@@ -9,7 +9,8 @@ class HomePageViewModel(generatorContext: GeneratorContext) : PageViewModel(gene
 
     val content = MarkdownViewModel(
         markdown = generatorContext.workspace.documentation.sections
-            .firstOrNull { it.order == 1 }?.content ?: DEFAULT_HOMEPAGE_CONTENT
+            .firstOrNull { it.order == 1 }?.content ?: DEFAULT_HOMEPAGE_CONTENT,
+        svgFactory = generatorContext.svgFactory
     )
 
     companion object {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownViewModel.kt
@@ -1,3 +1,3 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
-data class MarkdownViewModel(val markdown: String)
+data class MarkdownViewModel(val markdown: String, val svgFactory: (name: String) -> String)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -2,7 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
-abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
+abstract class PageViewModel(val generatorContext: GeneratorContext) {
     val pageTitle by lazy {
         if (generatorContext.workspace.name.isNotBlank())
             "$pageSubTitle | ${generatorContext.workspace.name}"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -2,7 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
-abstract class PageViewModel(val generatorContext: GeneratorContext) {
+abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
     val pageTitle by lazy {
         if (generatorContext.workspace.name.isNotBlank())
             "$pageSubTitle | ${generatorContext.workspace.name}"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModel.kt
@@ -8,5 +8,5 @@ class SoftwareSystemComponentPageViewModel(generatorContext: GeneratorContext, s
     val diagrams = generatorContext.workspace.views.componentViews
         .filter { it.softwareSystem == softwareSystem }
         .sortedBy { it.key }
-        .map { DiagramViewModel.forView(this, it) }
+        .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModel.kt
@@ -8,5 +8,5 @@ class SoftwareSystemContainerPageViewModel(generatorContext: GeneratorContext, s
     val diagrams = generatorContext.workspace.views.containerViews
         .filter { it.softwareSystem == softwareSystem }
         .sortedBy { it.key }
-        .map { DiagramViewModel.forView(this, it) }
+        .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModel.kt
@@ -8,5 +8,5 @@ class SoftwareSystemContextPageViewModel(generatorContext: GeneratorContext, sof
     val diagrams = generatorContext.workspace.views.systemContextViews
         .filter { it.softwareSystem == softwareSystem }
         .sortedBy { it.key }
-        .map { DiagramViewModel.forView(this, it) }
+        .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModel.kt
@@ -9,7 +9,7 @@ class SoftwareSystemDecisionPageViewModel(
 ) : SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DECISIONS) {
     override val url = url(softwareSystem, decision)
 
-    val markdown = MarkdownViewModel(decision.content)
+    val content = MarkdownViewModel(decision.content, generatorContext.svgFactory)
 
     companion object {
         fun url(softwareSystem: SoftwareSystem, decision: Decision) =

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModel.kt
@@ -8,5 +8,5 @@ class SoftwareSystemDeploymentPageViewModel(generatorContext: GeneratorContext, 
     val diagrams = generatorContext.workspace.views.deploymentViews
         .filter { it.softwareSystem == softwareSystem }
         .sortedBy { it.key }
-        .map { DiagramViewModel.forView(this, it) }
+        .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModel.kt
@@ -9,6 +9,9 @@ class SoftwareSystemHomePageViewModel(generatorContext: GeneratorContext, softwa
     val propertiesTable = createPropertiesTableViewModel(softwareSystem.properties)
     val content = softwareSystem.documentation.sections
         .minByOrNull { it.order }
-        ?.let { MarkdownViewModel(it.content) }
-        ?: MarkdownViewModel("# Description${System.lineSeparator()}${softwareSystem.description}")
+        ?.let { MarkdownViewModel(it.content, generatorContext.svgFactory) }
+        ?: MarkdownViewModel(
+            "# Description${System.lineSeparator()}${softwareSystem.description}",
+            generatorContext.svgFactory
+        )
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModel.kt
@@ -9,7 +9,7 @@ class SoftwareSystemSectionPageViewModel(
 ) : SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DECISIONS) {
     override val url = url(softwareSystem, section)
 
-    val markdown = MarkdownViewModel(section.content)
+    val content = MarkdownViewModel(section.content, generatorContext.svgFactory)
 
     companion object {
         fun url(softwareSystem: SoftwareSystem, section: Section) =

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModel.kt
@@ -8,7 +8,7 @@ class WorkspaceDecisionPageViewModel(generatorContext: GeneratorContext, decisio
     override val url = url(decision)
     override val pageSubTitle: String = decision.title
 
-    val markdown = MarkdownViewModel(decision.content)
+    val content = MarkdownViewModel(decision.content, generatorContext.svgFactory)
 
     companion object {
         fun url(decision: Decision) = "/decisions/${decision.id}"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDocumentationSectionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDocumentationSectionPageViewModel.kt
@@ -9,7 +9,7 @@ class WorkspaceDocumentationSectionPageViewModel(generatorContext: GeneratorCont
     override val url = url(section)
     override val pageSubTitle: String = section.title
 
-    val markdown = MarkdownViewModel(section.content)
+    val content = MarkdownViewModel(section.content, generatorContext.svgFactory)
 
     companion object {
         fun url(section: Section): String {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
@@ -5,7 +5,9 @@ import nl.avisi.structurizr.site.generatr.site.model.DiagramViewModel
 
 fun FlowContent.diagram(viewModel: DiagramViewModel) {
     figure {
-        img(src = viewModel.svgLocation.relativeHref, alt = viewModel.name)
+        unsafe {
+            +viewModel.svg
+        }
         figcaption {
             +viewModel.name
             +" ["

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Markdown.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Markdown.kt
@@ -13,9 +13,13 @@ import com.vladsch.flexmark.util.data.MutableDataSet
 import kotlinx.html.FlowContent
 import kotlinx.html.div
 import kotlinx.html.unsafe
+import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
 import nl.avisi.structurizr.site.generatr.site.model.MarkdownViewModel
 import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import java.io.File
 
 fun FlowContent.markdown(pageViewModel: PageViewModel, markdown: MarkdownViewModel) {
     div {
@@ -34,18 +38,20 @@ private fun markdownToHtml(pageViewModel: PageViewModel, markdown: MarkdownViewM
     val renderer = HtmlRenderer.builder(options)
         .linkResolverFactory(CustomLinkResolver.Factory(pageViewModel))
         .build()
-    val document = parser.parse(markdown.markdown)
+    val markDownDocument = parser.parse(markdown.markdown)
+    val html = renderer.render(markDownDocument)
 
-    return renderer.render(document)
+    return Jsoup.parse(html)
+        .apply { body().transformEmbeddedDiagramElements(pageViewModel) }
+        .html()
 }
 
 private class CustomLinkResolver(private val pageViewModel: PageViewModel) : LinkResolver {
     override fun resolveLink(node: Node, context: LinkResolverBasicContext, link: ResolvedLink): ResolvedLink {
         if (link.url.startsWith("embed:")) {
-            val diagramId = link.url.substring(6)
             return link
                 .withStatus(LinkStatus.VALID)
-                .withUrl("/svg/$diagramId.svg".asUrlRelativeTo(pageViewModel.url))
+                .withUrl(link.url)
         }
         if (link.url.matches("https?://.*".toRegex()))
             return link
@@ -66,3 +72,18 @@ private class CustomLinkResolver(private val pageViewModel: PageViewModel) : Lin
         override fun affectsGlobalScope() = false
     }
 }
+
+private fun Element.transformEmbeddedDiagramElements(pageViewModel: PageViewModel) = this.allElements
+    .toList()
+    .filter { it.tag().name == "img" && it.attr("src").startsWith("embed:") }
+    .forEach {
+        val diagramId = it.attr("src").substring(6)
+        val svg = File(svgPathname(pageViewModel.generatorContext, diagramId)).readText()
+        it.parent()?.append(svg)
+        it.remove()
+    }
+
+private fun svgPathname(
+    generatorContext: GeneratorContext,
+    diagramId: String
+) = "${generatorContext.exportDir}/${generatorContext.currentBranch}/svg/$diagramId.svg"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDecisionPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDecisionPage.kt
@@ -5,6 +5,6 @@ import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemDecisionPageV
 
 fun HTML.softwareSystemDecisionPage(viewModel: SoftwareSystemDecisionPageViewModel) {
     softwareSystemPage(viewModel) {
-        markdown(viewModel, viewModel.markdown)
+        markdown(viewModel, viewModel.content)
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionPage.kt
@@ -5,6 +5,6 @@ import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemSectionPageVi
 
 fun HTML.softwareSystemSectionPage(viewModel: SoftwareSystemSectionPageViewModel) {
     softwareSystemPage(viewModel) {
-        markdown(viewModel, viewModel.markdown)
+        markdown(viewModel, viewModel.content)
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/WorkspaceDecisionPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/WorkspaceDecisionPage.kt
@@ -6,7 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.WorkspaceDecisionPageViewMo
 fun HTML.workspaceDecisionPage(viewModel: WorkspaceDecisionPageViewModel) {
     page(viewModel) {
         contentDiv {
-            markdown(viewModel, viewModel.markdown)
+            markdown(viewModel, viewModel.content)
         }
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/WorkspaceDocumentationSectionPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/WorkspaceDocumentationSectionPage.kt
@@ -6,7 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.WorkspaceDocumentationSecti
 fun HTML.workspaceDocumentationSectionPage(viewModel: WorkspaceDocumentationSectionPageViewModel) {
     page(viewModel) {
         contentDiv {
-            markdown(viewModel, viewModel.markdown)
+            markdown(viewModel, viewModel.content)
         }
     }
 }

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -10,3 +10,7 @@
 .is-one-tenth {
     width: 10%;
 }
+
+svg a:hover {
+    opacity: 90%;
+}

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -7,6 +7,10 @@
     border-right: 1px solid #cccccc;
 }
 
+.container {
+    overflow-x: auto;
+}
+
 .is-one-tenth {
     width: 10%;
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
@@ -1,0 +1,64 @@
+package nl.avisi.structurizr.site.generatr.site
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.structurizr.Workspace
+import com.structurizr.model.SoftwareSystem
+import org.junit.jupiter.api.Test
+
+class C4PlantUmlExporterWithElementLinksTest {
+
+    @Test
+    fun `renders diagram`() {
+        val (workspace, system) = createWorkspace()
+        val view = workspace.views.createSystemContextView(system, "Context1", "")
+            .apply { addAllElements() }
+
+        val diagram = C4PlantUmlExporterWithElementLinks(workspace, "master")
+            .export(view)
+
+        assertThat(diagram.definition.withoutHeaderAndFooter()).isEqualTo(
+            """
+            System(System1, "System 1", "", ${'$'}tags="")
+            """.withoutTrailingSpaces()
+        )
+    }
+
+    @Test
+    fun `link to other software system`() {
+        val (workspace, system) = createWorkspace()
+        workspace.model.addSoftwareSystem("System 2").apply { uses(system, "uses") }
+        val view = workspace.views.createSystemContextView(system, "Context 1", "")
+            .apply { addAllElements() }
+
+        val diagram = C4PlantUmlExporterWithElementLinks(workspace, "master")
+            .export(view)
+
+        assertThat(diagram.definition.withoutHeaderAndFooter()).isEqualTo(
+            """
+            System(System1, "System 1", "", ${'$'}tags="")
+            System(System2, "System 2", "", ${'$'}tags="")[[/master/system-2/context/]]
+
+            Rel_D(System2, System1, "uses", ${'$'}tags="")
+            """.withoutTrailingSpaces()
+        )
+    }
+
+    private fun createWorkspace(): Pair<Workspace, SoftwareSystem> {
+        val workspace = Workspace("workspace name", "")
+        val system = workspace.model.addSoftwareSystem("System 1")
+        return workspace to system
+    }
+
+    private fun String.withoutHeaderAndFooter() = this
+        .split(System.lineSeparator())
+        .drop(7)
+        .dropLast(3)
+        .joinToString(System.lineSeparator())
+        .trimEnd()
+
+    private fun String.withoutTrailingSpaces() = this
+        .split(System.lineSeparator())
+        .joinToString(System.lineSeparator()) { it.trim() }
+        .trimEnd()
+}

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModelTest.kt
@@ -23,7 +23,7 @@ class HomePageViewModelTest : ViewModelTest() {
         val viewModel = HomePageViewModel(generatorContext)
 
         assertThat(viewModel.content)
-            .isEqualTo(MarkdownViewModel(DEFAULT_HOMEPAGE_CONTENT))
+            .isEqualTo(MarkdownViewModel(DEFAULT_HOMEPAGE_CONTENT, svgFactory))
     }
 
     @Test
@@ -35,7 +35,7 @@ class HomePageViewModelTest : ViewModelTest() {
         val viewModel = HomePageViewModel(generatorContext)
 
         assertThat(viewModel.content)
-            .isEqualTo(MarkdownViewModel("Section content"))
+            .isEqualTo(MarkdownViewModel("Section content", svgFactory))
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModelTest.kt
@@ -30,12 +30,14 @@ class SoftwareSystemComponentPageViewModelTest : ViewModelTest() {
         assertThat(viewModel.diagrams).containsExactly(
             DiagramViewModel(
                 "Software system - Backend - Components",
+                "<svg></svg>",
                 ImageViewModel(viewModel, "/svg/component-1.svg"),
                 ImageViewModel(viewModel, "/png/component-1.png"),
                 ImageViewModel(viewModel, "/puml/component-1.puml")
             ),
             DiagramViewModel(
                 "Software system - Backend - Components",
+                "<svg></svg>",
                 ImageViewModel(viewModel, "/svg/component-2.svg"),
                 ImageViewModel(viewModel, "/png/component-2.png"),
                 ImageViewModel(viewModel, "/puml/component-2.puml")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
@@ -29,12 +29,14 @@ class SoftwareSystemContainerPageViewModelTest : ViewModelTest() {
         assertThat(viewModel.diagrams).containsExactly(
             DiagramViewModel(
                 "Software system - Containers",
+                "<svg></svg>",
                 ImageViewModel(viewModel, "/svg/container-1.svg"),
                 ImageViewModel(viewModel, "/png/container-1.png"),
                 ImageViewModel(viewModel, "/puml/container-1.puml")
             ),
             DiagramViewModel(
                 "Software system - Containers",
+                "<svg></svg>",
                 ImageViewModel(viewModel, "/svg/container-2.svg"),
                 ImageViewModel(viewModel, "/png/container-2.png"),
                 ImageViewModel(viewModel, "/puml/container-2.puml")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
@@ -20,12 +20,14 @@ class SoftwareSystemContextPageViewModelTest : ViewModelTest() {
         assertThat(viewModel.diagrams).containsExactly(
             DiagramViewModel(
                 "Software system - System Context",
+                "<svg></svg>",
                 ImageViewModel(viewModel, "/svg/context-1.svg"),
                 ImageViewModel(viewModel, "/png/context-1.png"),
                 ImageViewModel(viewModel, "/puml/context-1.puml")
             ),
             DiagramViewModel(
                 "Software system - System Context",
+                "<svg></svg>",
                 ImageViewModel(viewModel, "/svg/context-2.svg"),
                 ImageViewModel(viewModel, "/png/context-2.png"),
                 ImageViewModel(viewModel, "/puml/context-2.puml")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModelTest.kt
@@ -33,6 +33,6 @@ class SoftwareSystemDecisionPageViewModelTest : ViewModelTest() {
         val decision = createDecision()
         val viewModel = SoftwareSystemDecisionPageViewModel(generatorContext, softwareSystem, decision)
 
-        assertThat(viewModel.markdown).isEqualTo(MarkdownViewModel(decision.content))
+        assertThat(viewModel.content).isEqualTo(MarkdownViewModel(decision.content, svgFactory))
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
@@ -29,12 +29,14 @@ class SoftwareSystemDeploymentPageViewModelTest : ViewModelTest() {
         assertThat(viewModel.diagrams).containsExactly(
             DiagramViewModel(
                 "Software system - Deployment - Default",
+                "<svg></svg>",
                 ImageViewModel(viewModel, "/svg/deployment-1.svg"),
                 ImageViewModel(viewModel, "/png/deployment-1.png"),
                 ImageViewModel(viewModel, "/puml/deployment-1.puml")
             ),
             DiagramViewModel(
                 "Software system - Deployment - Default",
+                "<svg></svg>",
                 ImageViewModel(viewModel, "/svg/deployment-2.svg"),
                 ImageViewModel(viewModel, "/png/deployment-2.png"),
                 ImageViewModel(viewModel, "/puml/deployment-2.puml")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModelTest.kt
@@ -33,6 +33,6 @@ class SoftwareSystemSectionPageViewModelTest : ViewModelTest() {
         val section = createSection()
         val viewModel = SoftwareSystemSectionPageViewModel(generatorContext, softwareSystem, section)
 
-        assertThat(viewModel.markdown).isEqualTo(MarkdownViewModel(section.content))
+        assertThat(viewModel.content).isEqualTo(MarkdownViewModel(section.content, svgFactory))
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
@@ -5,18 +5,19 @@ import com.structurizr.documentation.Decision
 import com.structurizr.documentation.Format
 import com.structurizr.documentation.Section
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
-import java.io.File
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
 
 abstract class ViewModelTest {
+    protected val svgFactory = { _: String -> "<svg></svg>" }
+
     protected fun generatorContext(
         workspaceName: String = "workspace name",
         branches: List<String> = listOf("main"),
         currentBranch: String = "main",
         version: String = "1.0.0"
-    ) = GeneratorContext(version, Workspace(workspaceName, ""), File("export-dir"), branches, currentBranch)
+    ) = GeneratorContext(version, Workspace(workspaceName, ""), branches, currentBranch, svgFactory)
 
     protected fun pageViewModel(pageHref: String = "/some-page") = object : PageViewModel(generatorContext()) {
         override val url = pageHref

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
@@ -5,6 +5,7 @@ import com.structurizr.documentation.Decision
 import com.structurizr.documentation.Format
 import com.structurizr.documentation.Section
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
+import java.io.File
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
@@ -15,7 +16,7 @@ abstract class ViewModelTest {
         branches: List<String> = listOf("main"),
         currentBranch: String = "main",
         version: String = "1.0.0"
-    ) = GeneratorContext(version, Workspace(workspaceName, ""), branches, currentBranch)
+    ) = GeneratorContext(version, Workspace(workspaceName, ""), File("export-dir"), branches, currentBranch)
 
     protected fun pageViewModel(pageHref: String = "/some-page") = object : PageViewModel(generatorContext()) {
         override val url = pageHref

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModelTest.kt
@@ -28,6 +28,6 @@ class WorkspaceDecisionPageViewModelTest : ViewModelTest() {
         val decision = createDecision()
         val viewModel = WorkspaceDecisionPageViewModel(generatorContext(), decision)
 
-        assertThat(viewModel.markdown).isEqualTo(MarkdownViewModel(decision.content))
+        assertThat(viewModel.content).isEqualTo(MarkdownViewModel(decision.content, svgFactory))
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDocumentationSectionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDocumentationSectionPageViewModelTest.kt
@@ -2,8 +2,6 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.structurizr.documentation.Format
-import com.structurizr.documentation.Section
 import kotlin.test.Test
 
 class WorkspaceDocumentationSectionPageViewModelTest : ViewModelTest() {
@@ -40,6 +38,6 @@ class WorkspaceDocumentationSectionPageViewModelTest : ViewModelTest() {
         val section = createSection()
         val viewModel = WorkspaceDocumentationSectionPageViewModel(generatorContext, section)
 
-        assertThat(viewModel.markdown).isEqualTo(MarkdownViewModel(section.content))
+        assertThat(viewModel.content).isEqualTo(MarkdownViewModel(section.content, svgFactory))
     }
 }


### PR DESCRIPTION
Creating as a draft since embedding the svg images directly into the html (esp. for markdown) is not that clean.

Please also note that the diagrams are no longer scaled, thus they are always shown with 100% size. I think this is a good thing, but may be not everyone agrees.