### PR TITLE
Improve serve experience

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
     implementation("org.eclipse.jetty:jetty-server:11.0.12")
     implementation("org.eclipse.jetty:jetty-servlet:11.0.12")
+    implementation("org.eclipse.jetty.websocket:websocket-jetty-server:11.0.12")
 
     runtimeOnly("org.slf4j:slf4j-simple:2.0.3")
     runtimeOnly("org.jetbrains.kotlin:kotlin-scripting-jsr223:1.7.20")

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -154,6 +154,10 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
     }
 
     views {
+        properties {
+            "c4plantuml.elementProperties" "true"
+        }
+
         systemlandscape "SystemLandscape" {
             include *
             autoLayout

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/CreateStructurizrWorkspace.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/CreateStructurizrWorkspace.kt
@@ -10,7 +10,6 @@ fun createStructurizrWorkspace(workspaceFile: File) =
         .apply { parse(workspaceFile) }
         .workspace
         .apply {
-            views.configuration.addProperty(C4PlantUMLExporter.C4PLANTUML_ELEMENT_PROPERTIES_PROPERTY, true.toString())
             model.elements.forEach {
                 moveUrlToProperty(it) // We need the URL later for our own links, preserve the original in a property
             }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -64,7 +64,8 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
             assetsDir?.let { File(it) },
             File(siteDir),
             listOf(branch),
-            branch
+            branch,
+            serving = true
         )
 
         println("Successfully generated diagrams and site")

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -112,6 +112,8 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
         while (true) {
             val watchKey = watchService.take()
             val parentPath = watchKey.watchable() as Path
+
+            Thread.sleep(100) // Throttle the file watcher to give editors time for cleaning up temporary files
             val events = watchKey.pollEvents().filterNot { isHashFile(it) }
 
             val fileModified = events.map { parentPath.resolve(it.context() as Path) }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -24,6 +24,7 @@ import java.time.Duration
 import kotlin.io.path.extension
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
+import kotlin.system.measureTimeMillis
 
 class ServeCommand : Subcommand("serve", "Start a development server") {
     private val workspaceFile by option(
@@ -62,27 +63,29 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
         val exportDir = File(siteDir, branch)
 
         try {
-            broadcast("site-updating")
-            val workspace = createStructurizrWorkspace(File(workspaceFile))
-            println("Generating diagrams...")
-            generateDiagrams(workspace, exportDir)
+            val ms = measureTimeMillis {
+                broadcast("site-updating")
+                val workspace = createStructurizrWorkspace(File(workspaceFile))
+                println("Generating diagrams...")
+                generateDiagrams(workspace, exportDir)
 
-            println("Generating site...")
-            copySiteWideAssets(File(siteDir))
-            generateRedirectingIndexPage(File(siteDir), branch)
-            generateSite(
-                "0.0.0",
-                workspace,
-                assetsDir?.let { File(it) },
-                File(siteDir),
-                listOf(branch),
-                branch,
-                serving = true
-            )
+                println("Generating site...")
+                copySiteWideAssets(File(siteDir))
+                generateRedirectingIndexPage(File(siteDir), branch)
+                generateSite(
+                    "0.0.0",
+                    workspace,
+                    assetsDir?.let { File(it) },
+                    File(siteDir),
+                    listOf(branch),
+                    branch,
+                    serving = true
+                )
 
-            updateSiteError = null
-            broadcast("site-updated")
-            println("Successfully generated diagrams and site")
+                updateSiteError = null
+                broadcast("site-updated")
+            }
+            println("Successfully generated diagrams and site in ${ms.toDouble() / 1000} seconds")
         } catch (e: Exception) {
             updateSiteError = e.message ?: "Unknown error"
             broadcast(updateSiteError!!)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/GeneratorContext.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/GeneratorContext.kt
@@ -7,5 +7,6 @@ data class GeneratorContext(
     val workspace: Workspace,
     val branches: List<String>,
     val currentBranch: String,
+    val serving: Boolean,
     val svgFactory: (key: String, url: String) -> String
 )

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModel.kt
@@ -10,7 +10,8 @@ class MenuViewModel(generatorContext: GeneratorContext, private val pageViewMode
         if (generatorContext.workspace.documentation.decisions.isNotEmpty())
             yield(createMenuItem("Decisions", WorkspaceDecisionsPageViewModel.url(), false))
 
-        yield(createMenuItem("Software Systems", SoftwareSystemsPageViewModel.url()))
+        if (generatorContext.workspace.model.softwareSystems.isNotEmpty())
+            yield(createMenuItem("Software Systems", SoftwareSystemsPageViewModel.url()))
 
         generatorContext.workspace.documentation.sections
             .sortedBy { it.order }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -11,6 +11,7 @@ abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
     }
     val headerBar by lazy { HeaderBarViewModel(this, generatorContext) }
     val menu by lazy { MenuViewModel(generatorContext, this) }
+    val includeAutoReloading = generatorContext.serving
 
     abstract val url: String
     abstract val pageSubTitle: String

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -22,6 +22,7 @@ private fun HTML.headFragment(viewModel: PageViewModel) {
             rel = "stylesheet",
             href = "../" + "/style.css".asUrlRelativeTo(viewModel.url)
         )
+
         if (viewModel.includeAutoReloading)
             script(
                 type = ScriptType.textJavaScript,
@@ -35,10 +36,26 @@ private fun HTML.bodyFragment(viewModel: PageViewModel, block: DIV.() -> Unit) {
         pageHeader(viewModel.headerBar)
 
         div(classes = "site-layout") {
+            id = "site"
             menu(viewModel.menu)
             div(classes = "container is-fluid has-background-white") {
                 block()
             }
         }
+
+        if (viewModel.includeAutoReloading)
+            div(classes = "container is-hidden") {
+                id = "hero"
+                div(classes = "hero is-danger mt-6") {
+                    div(classes = "hero-body") {
+                        p(classes = "title") {
+                            text("Error loading workspace file")
+                        }
+                        p(classes = "subtitle") {
+                            id = "hero-subtitle"
+                        }
+                    }
+                }
+            }
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -16,12 +16,17 @@ private fun HTML.headFragment(viewModel: PageViewModel) {
     head {
         meta(charset = "utf-8")
         meta(name = "viewport", content = "width=device-width, initial-scale=1")
+        title { +viewModel.pageTitle }
         link(rel = "stylesheet", href = "https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css")
         link(
             rel = "stylesheet",
             href = "../" + "/style.css".asUrlRelativeTo(viewModel.url)
         )
-        title { +viewModel.pageTitle }
+        if (viewModel.includeAutoReloading)
+            script(
+                type = ScriptType.textJavaScript,
+                src = "../" + "/auto-reload.js".asUrlRelativeTo(viewModel.url)
+            ) { }
     }
 }
 

--- a/src/main/resources/assets/js/auto-reload.js
+++ b/src/main/resources/assets/js/auto-reload.js
@@ -1,0 +1,30 @@
+let hash = undefined;
+
+function reloadIfNeeded() {
+    fetch(window.location + "index.html.md5")
+        .then((response) => {
+            if (!response.ok) {
+                throw Error(response.statusText.toLowerCase())
+            }
+            return response.text()
+        })
+        .then((content) => {
+            if (!hash) {
+                hash = content;
+            } else if (hash !== content) {
+                console.log("Page content change detected, reloading ...")
+                location.reload()
+            } else {
+                console.log("Page content has not been changed.")
+            }
+        })
+        .catch((error) => {
+            if (error.message === "not found") {
+                location.href = location.origin
+            } else {
+                console.log(error)
+            }
+        });
+}
+
+setInterval(reloadIfNeeded, 200);

--- a/src/main/resources/assets/js/auto-reload.js
+++ b/src/main/resources/assets/js/auto-reload.js
@@ -27,4 +27,26 @@ function reloadIfNeeded() {
         });
 }
 
-setInterval(reloadIfNeeded, 200);
+function connectToWs() {
+    const ws = new WebSocket("ws://" + location.host + "/_events");
+    ws.onopen = () => {
+        console.log("Connected to socket.");
+        reloadIfNeeded();
+    }
+    ws.onclose = (event) => {
+        console.log('Socket has been closed. Attempting to reconnect ...', event.reason);
+        setTimeout(() => connectToWs(), 1000);
+    };
+    ws.onmessage = (event) => {
+        if (event.data === "site-updating") {
+            console.log("Site updating ...")
+        } else if (event.data === "site-updated") {
+            console.log("Site update detected, detect page content change ...")
+            reloadIfNeeded();
+        } else {
+            console.log(event.data)
+        }
+    }
+}
+
+connectToWs();

--- a/src/main/resources/assets/js/auto-reload.js
+++ b/src/main/resources/assets/js/auto-reload.js
@@ -42,9 +42,14 @@ function connectToWs() {
             console.log("Site updating ...")
         } else if (event.data === "site-updated") {
             console.log("Site update detected, detect page content change ...")
+            document.getElementById("site").classList.remove("is-hidden")
+            document.getElementById("hero").classList.add("is-hidden")
             reloadIfNeeded();
         } else {
             console.log(event.data)
+            document.getElementById("hero-subtitle").innerText = event.data
+            document.getElementById("site").classList.add("is-hidden")
+            document.getElementById("hero").classList.remove("is-hidden")
         }
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.structurizr.Workspace
 import com.structurizr.view.SystemContextView
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 
 class C4PlantUmlExporterWithElementLinksTest {
 

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModelTest.kt
@@ -24,6 +24,20 @@ class MenuViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.generalItems).containsExactly(
             LinkViewModel(pageViewModel, "Home", HomePageViewModel.url()),
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["main", "branch-2"])
+    fun `software systems menu item if available`(currentBranch: String) {
+        val generatorContext = generatorContext(branches = listOf("main", "branch-2"), currentBranch = currentBranch)
+            .apply {
+                workspace.model.addSoftwareSystem("Software system 1")
+            }
+        val pageViewModel = createPageViewModel(generatorContext)
+        val viewModel = MenuViewModel(generatorContext, pageViewModel)
+
+        assertThat(viewModel.generalItems[1]).isEqualTo(
             LinkViewModel(pageViewModel, "Software Systems", SoftwareSystemsPageViewModel.url())
         )
     }
@@ -60,7 +74,7 @@ class MenuViewModelTest : ViewModelTest() {
         val pageViewModel = createPageViewModel(generatorContext)
         val viewModel = MenuViewModel(generatorContext, pageViewModel)
 
-        assertThat(viewModel.generalItems.drop(2)).containsExactly(
+        assertThat(viewModel.generalItems.drop(1)).containsExactly(
             LinkViewModel(pageViewModel, "Doc 1", WorkspaceDocumentationSectionPageViewModel.url(section1)),
             LinkViewModel(pageViewModel, "Doc Title 2", WorkspaceDocumentationSectionPageViewModel.url(section2))
         )

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
@@ -17,7 +17,7 @@ abstract class ViewModelTest {
         branches: List<String> = listOf("main"),
         currentBranch: String = "main",
         version: String = "1.0.0"
-    ) = GeneratorContext(version, Workspace(workspaceName, ""), branches, currentBranch, svgFactory)
+    ) = GeneratorContext(version, Workspace(workspaceName, ""), branches, currentBranch, false, svgFactory)
 
     protected fun pageViewModel(pageHref: String = "/some-page") = object : PageViewModel(generatorContext()) {
         override val url = pageHref


### PR DESCRIPTION
This PR improves the serving experience with
- Auto reload changes in the generated site (Solves https://github.com/avisi-cloud/structurizr-site-generatr/issues/42)
- Show loading/parsing error directly in the generated site.

This should make editing and viewing DSL sites much more pleasant, no need anymore to keep an eye on the console for any errors and also no need anymore for manual refreshes.
~Note that the polling in the browser is not the most elegant way, but it is simple and straight forward. Doing something with e.g. web-sockets could be a thing for later.~ Switching to web sockets turned out to be easier than I thought, so web sockets are used to send a signal to browsers.

This PR is based on https://github.com/avisi-cloud/structurizr-site-generatr/pull/80 , so reviewing the other PR first makes sense. 