### PR TITLE
Scale diagrams down when the width doesn't fit in the browser window

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
@@ -34,6 +34,12 @@ class C4PlantUmlExporterWithElementLinks(
         }
     }
 
+    override fun writeHeader(view: View, writer: IndentingWriter) {
+        super.writeHeader(view, writer)
+        writer.writeLine("skinparam svgDimensionStyle false")
+        writer.writeLine("skinparam preserveAspectRatio meet")
+    }
+
     override fun writeElement(view: View?, element: Element?, writer: IndentingWriter?) {
         if (element !is SoftwareSystem || !element.linkNeeded(view))
             return super.writeElement(view, element, writer)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
@@ -4,7 +4,14 @@ import kotlinx.html.*
 import nl.avisi.structurizr.site.generatr.site.model.DiagramViewModel
 
 fun FlowContent.diagram(viewModel: DiagramViewModel) {
+    val diagramWidthInPixels = "viewBox=\"\\d+ \\d+ (\\d+) \\d+\"".toRegex()
+        .find(viewModel.svg)
+        ?.let { it.groupValues[1].toInt() }
+        ?: throw IllegalStateException("No viewBox attribute found in SVG!")
+
     figure {
+        style = "width: min(100%, ${diagramWidthInPixels}px);"
+
         unsafe {
             +viewModel.svg
         }

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -7,10 +7,6 @@
     border-right: 1px solid #cccccc;
 }
 
-.container {
-    overflow-x: auto;
-}
-
 .is-front-centered {
     width: 40%;
     margin-left: 30%;

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
@@ -1,12 +1,34 @@
 package nl.avisi.structurizr.site.generatr.site
 
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import com.structurizr.Workspace
 import com.structurizr.view.SystemContextView
 import kotlin.test.Test
 
 class C4PlantUmlExporterWithElementLinksTest {
+    @Test
+    fun `adds skinparam to remove explicit size from generated svg`() {
+        val view = createWorkspaceWithOneSystem()
+
+        val diagram = C4PlantUmlExporterWithElementLinks("/landscape/")
+            .export(view)
+
+        assertThat(diagram.definition)
+            .contains("skinparam svgDimensionStyle false")
+    }
+
+    @Test
+    fun `adds skinparam to preserve the aspect ratio of the generated svg`() {
+        val view = createWorkspaceWithOneSystem()
+
+        val diagram = C4PlantUmlExporterWithElementLinks("/landscape/")
+            .export(view)
+
+        assertThat(diagram.definition)
+            .contains("skinparam preserveAspectRatio meet")
+    }
 
     @Test
     fun `renders diagram`() {

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
@@ -18,7 +18,7 @@ class C4PlantUmlExporterWithElementLinksTest {
         assertThat(diagram.definition.withoutHeaderAndFooter()).isEqualTo(
             """
             System(System1, "System 1", "", ${'$'}tags="")
-            """.withoutTrailingSpaces()
+            """.trimIndent()
         )
     }
 
@@ -35,7 +35,7 @@ class C4PlantUmlExporterWithElementLinksTest {
             System(System2, "System 2", "", ${'$'}tags="")[[../system-2/context]]
 
             Rel_D(System2, System1, "uses", ${'$'}tags="")
-            """.withoutTrailingSpaces()
+            """.trimIndent()
         )
     }
 
@@ -52,7 +52,7 @@ class C4PlantUmlExporterWithElementLinksTest {
             System(System2, "System 2", "", ${'$'}tags="")[[../../system-2/context]]
 
             Rel_D(System2, System1, "uses", ${'$'}tags="")
-            """.withoutTrailingSpaces()
+            """.trimIndent()
         )
     }
 
@@ -75,13 +75,8 @@ class C4PlantUmlExporterWithElementLinksTest {
 
     private fun String.withoutHeaderAndFooter() = this
         .split(System.lineSeparator())
-        .drop(7)
+        .drop(10)
         .dropLast(3)
         .joinToString(System.lineSeparator())
-        .trimEnd()
-
-    private fun String.withoutTrailingSpaces() = this
-        .split(System.lineSeparator())
-        .joinToString(System.lineSeparator()) { it.trim() }
         .trimEnd()
 }


### PR DESCRIPTION
With the change to make diagram elements clickable, the scaling of diagrams on the page was changed as well. This PR brings back the original diagram scaling:

- If the diagram width fits within the available view width within the browser window, the diagram is rendered at 100%.
- If the diagram does not fit within the available view width within the browser window, the diagram is scaled down to fit.