### PR TITLE
Fix diagram links to software systems without system context view

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
@@ -1,5 +1,6 @@
 package nl.avisi.structurizr.site.generatr.site
 
+import com.structurizr.Workspace
 import com.structurizr.export.Diagram
 import com.structurizr.export.IndentingWriter
 import com.structurizr.export.plantuml.C4PlantUMLExporter
@@ -17,8 +18,9 @@ import nl.avisi.structurizr.site.generatr.includedSoftwareSystem
 import nl.avisi.structurizr.site.generatr.normalize
 
 class C4PlantUmlExporterWithElementLinks(
+    private val workspace: Workspace,
     private val url: String
-): C4PlantUMLExporter() {
+) : C4PlantUMLExporter() {
     companion object {
         const val TEMP_URI = "https://will-be-changed-to-relative/"
 
@@ -53,9 +55,15 @@ class C4PlantUmlExporterWithElementLinks(
         this is SoftwareSystem && this.includedSoftwareSystem && this != view?.softwareSystem
 
     private fun setElementUrl(element: Element) {
-        val path = "/${element.name.normalize()}/context/".asUrlRelativeTo(url)
-        element.url = "${TEMP_URI}$path"
+        val root = "/${element.name.normalize()}"
+        val path = if (isContextViewDefinedFor(element)) "$root/context/" else "$root/"
+
+        element.url = TEMP_URI + path.asUrlRelativeTo(url)
     }
+
+    private fun isContextViewDefinedFor(element: Element) =
+        workspace.views.systemContextViews
+            .any { it.softwareSystem == element }
 
     private fun writeModifiedElement(
         view: View?,

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
@@ -33,11 +33,11 @@ fun generateDiagrams(workspace: Workspace, exportDir: File) {
         }
 }
 
-fun generateDiagramWithElementLinks(view: View, url: String, exportDir: File): String {
+fun generateDiagramWithElementLinks(workspace: Workspace, view: View, url: String, exportDir: File): String {
     val pumlDir = pumlDir(exportDir)
     val svgDir = svgDir(exportDir)
 
-    val diagram = generatePlantUMLDiagramWithElementLinks(view, url)
+    val diagram = generatePlantUMLDiagramWithElementLinks(workspace, view, url)
 
     val name = "${diagram.key}-${view.key}"
     val plantUMLFile = File(pumlDir, "$name.puml")
@@ -84,8 +84,8 @@ private fun readSvg(svgDir: File, name: String): String {
     return svgFile.readText()
 }
 
-private fun generatePlantUMLDiagramWithElementLinks(view: View, url: String): Diagram {
-    val plantUMLExporter = C4PlantUmlExporterWithElementLinks(url)
+private fun generatePlantUMLDiagramWithElementLinks(workspace: Workspace, view: View, url: String): Diagram {
+    val plantUMLExporter = C4PlantUmlExporterWithElementLinks(workspace, url)
 
     return plantUMLExporter.export(view)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -55,7 +55,7 @@ fun generateSite(
 ) {
     val generatorContext = GeneratorContext(version, workspace, branches, currentBranch, serving) { key, url ->
         val view = workspace.views.views.single { view -> view.key == key }
-        generateDiagramWithElementLinks(view, url, exportDir)
+        generateDiagramWithElementLinks(workspace, view, url, exportDir)
     }
 
     deleteOldHashes(exportDir)


### PR DESCRIPTION
Currently, links in diagrams to software systems without a system context view lead to a page with no content and no active tab in the tab bar:

![image](https://user-images.githubusercontent.com/3872163/203063205-9fb8a664-bb4d-4b73-9a07-1f8083024134.png)

This PR fixes this by linking to the info page in these cases.