### PR TITLE
Streamline diagram presentation in markdowns

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/GeneratorContext.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/GeneratorContext.kt
@@ -8,5 +8,5 @@ data class GeneratorContext(
     val branches: List<String>,
     val currentBranch: String,
     val serving: Boolean,
-    val svgFactory: (key: String, url: String) -> String
+    val svgFactory: (key: String, url: String) -> String?
 )

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -54,8 +54,8 @@ fun generateSite(
     serving: Boolean = false
 ) {
     val generatorContext = GeneratorContext(version, workspace, branches, currentBranch, serving) { key, url ->
-        val view = workspace.views.views.single { view -> view.key == key }
-        generateDiagramWithElementLinks(view, url, exportDir)
+        workspace.views.views.singleOrNull { view -> view.key == key }
+            ?.let { generateDiagramWithElementLinks(it, url, exportDir) }
     }
 
     deleteOldHashes(exportDir)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
@@ -3,19 +3,41 @@ package nl.avisi.structurizr.site.generatr.site.model
 import com.structurizr.view.View
 
 data class DiagramViewModel(
+    val key: String,
     val name: String,
-    val svg: String,
+    val svg: String?,
+    val diagramWidthInPixels: Int?,
     val svgLocation: ImageViewModel,
     val pngLocation: ImageViewModel,
     val pumlLocation: ImageViewModel
 ) {
     companion object {
-        fun forView(pageViewModel: PageViewModel, view: View, svgFactory: (key: String, url: String) -> String) = DiagramViewModel(
-            view.name,
-            svgFactory(view.key, pageViewModel.url),
-            ImageViewModel(pageViewModel, "/svg/${view.key}.svg"),
-            ImageViewModel(pageViewModel, "/png/${view.key}.png"),
-            ImageViewModel(pageViewModel, "/puml/${view.key}.puml")
-        )
+        fun forView(pageViewModel: PageViewModel, view: View, svgFactory: (key: String, url: String) -> String?) =
+            forView(pageViewModel, view.key, view.name, svgFactory)
+
+        fun forView(
+            pageViewModel: PageViewModel,
+            key: String, name: String,
+            svgFactory: (key: String, url: String) -> String?
+        ): DiagramViewModel {
+            val svg = svgFactory(key, pageViewModel.url)
+            return DiagramViewModel(
+                key,
+                name,
+                svg,
+                extractDiagramWidthInPixels(svg),
+                ImageViewModel(pageViewModel, "/svg/${key}.svg"),
+                ImageViewModel(pageViewModel, "/png/${key}.png"),
+                ImageViewModel(pageViewModel, "/puml/${key}.puml")
+            )
+        }
+
+        private fun extractDiagramWidthInPixels(svg: String?) =
+            if (svg != null)
+                "viewBox=\"\\d+ \\d+ (\\d+) \\d+\"".toRegex()
+                    .find(svg)
+                    ?.let { it.groupValues[1].toInt() }
+                    ?: throw IllegalStateException("No viewBox attribute found in SVG!")
+            else null
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModel.kt
@@ -7,7 +7,8 @@ class HomePageViewModel(generatorContext: GeneratorContext) : PageViewModel(gene
     override val pageSubTitle = "Home"
     override val url = url()
 
-    val content = MarkdownViewModel(
+    val content = markdownToHtml(
+        this,
         markdown = generatorContext.workspace.documentation.sections
             .firstOrNull { it.order == 1 }?.content ?: DEFAULT_HOMEPAGE_CONTENT,
         svgFactory = generatorContext.svgFactory

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtml.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtml.kt
@@ -1,4 +1,4 @@
-package nl.avisi.structurizr.site.generatr.site.views
+package nl.avisi.structurizr.site.generatr.site.model
 
 import com.vladsch.flexmark.ext.tables.TablesExtension
 import com.vladsch.flexmark.html.HtmlRenderer
@@ -10,26 +10,14 @@ import com.vladsch.flexmark.html.renderer.ResolvedLink
 import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.ast.Node
 import com.vladsch.flexmark.util.data.MutableDataSet
-import kotlinx.html.FlowContent
 import kotlinx.html.div
 import kotlinx.html.stream.createHTML
-import kotlinx.html.unsafe
 import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
-import nl.avisi.structurizr.site.generatr.site.model.DiagramViewModel
-import nl.avisi.structurizr.site.generatr.site.model.MarkdownViewModel
-import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
+import nl.avisi.structurizr.site.generatr.site.views.diagram
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 
-fun FlowContent.markdown(pageViewModel: PageViewModel, markdownViewModel: MarkdownViewModel) {
-    div {
-        unsafe {
-            +markdownToHtml(pageViewModel, markdownViewModel)
-        }
-    }
-}
-
-private fun markdownToHtml(pageViewModel: PageViewModel, markdownViewModel: MarkdownViewModel): String {
+fun markdownToHtml(pageViewModel: PageViewModel, markdown: String, svgFactory: (key: String, url: String) -> String?): String {
     val options = MutableDataSet()
 
     options.set(Parser.EXTENSIONS, listOf(TablesExtension.create()))
@@ -38,11 +26,11 @@ private fun markdownToHtml(pageViewModel: PageViewModel, markdownViewModel: Mark
     val renderer = HtmlRenderer.builder(options)
         .linkResolverFactory(CustomLinkResolver.Factory(pageViewModel))
         .build()
-    val markDownDocument = parser.parse(markdownViewModel.markdown)
+    val markDownDocument = parser.parse(markdown)
     val html = renderer.render(markDownDocument)
 
     return Jsoup.parse(html)
-        .apply { body().transformEmbeddedDiagramElements(pageViewModel, markdownViewModel.svgFactory) }
+        .apply { body().transformEmbeddedDiagramElements(pageViewModel, svgFactory) }
         .body()
         .html()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownViewModel.kt
@@ -1,3 +1,0 @@
-package nl.avisi.structurizr.site.generatr.site.model
-
-data class MarkdownViewModel(val markdown: String, val svgFactory: (key: String, url: String) -> String?)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownViewModel.kt
@@ -1,3 +1,3 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
-data class MarkdownViewModel(val markdown: String, val svgFactory: (key: String, url: String) -> String)
+data class MarkdownViewModel(val markdown: String, val svgFactory: (key: String, url: String) -> String?)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModel.kt
@@ -9,7 +9,7 @@ class SoftwareSystemDecisionPageViewModel(
 ) : SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DECISIONS) {
     override val url = url(softwareSystem, decision)
 
-    val content = MarkdownViewModel(decision.content, generatorContext.svgFactory)
+    val content = markdownToHtml(this, decision.content, generatorContext.svgFactory)
 
     companion object {
         fun url(softwareSystem: SoftwareSystem, decision: Decision) =

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModel.kt
@@ -7,11 +7,10 @@ class SoftwareSystemHomePageViewModel(generatorContext: GeneratorContext, softwa
     SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.HOME) {
     val hasProperties = softwareSystem.properties.any()
     val propertiesTable = createPropertiesTableViewModel(softwareSystem.properties)
-    val content = softwareSystem.documentation.sections
+    val content = markdownToHtml(this, softwareSystem.info(), generatorContext.svgFactory)
+
+    private fun SoftwareSystem.info() = documentation.sections
         .minByOrNull { it.order }
-        ?.let { MarkdownViewModel(it.content, generatorContext.svgFactory) }
-        ?: MarkdownViewModel(
-            "# Description${System.lineSeparator()}${softwareSystem.description}",
-            generatorContext.svgFactory
-        )
+        ?.content
+        ?: "# Description${System.lineSeparator()}${description}"
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModel.kt
@@ -9,7 +9,7 @@ class SoftwareSystemSectionPageViewModel(
 ) : SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DECISIONS) {
     override val url = url(softwareSystem, section)
 
-    val content = MarkdownViewModel(section.content, generatorContext.svgFactory)
+    val content = markdownToHtml(this, section.content, generatorContext.svgFactory)
 
     companion object {
         fun url(softwareSystem: SoftwareSystem, section: Section) =

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModel.kt
@@ -8,7 +8,7 @@ class WorkspaceDecisionPageViewModel(generatorContext: GeneratorContext, decisio
     override val url = url(decision)
     override val pageSubTitle: String = decision.title
 
-    val content = MarkdownViewModel(decision.content, generatorContext.svgFactory)
+    val content = markdownToHtml(this, decision.content, generatorContext.svgFactory)
 
     companion object {
         fun url(decision: Decision) = "/decisions/${decision.id}"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDocumentationSectionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDocumentationSectionPageViewModel.kt
@@ -9,7 +9,7 @@ class WorkspaceDocumentationSectionPageViewModel(generatorContext: GeneratorCont
     override val url = url(section)
     override val pageSubTitle: String = section.title
 
-    val content = MarkdownViewModel(section.content, generatorContext.svgFactory)
+    val content = markdownToHtml(this, section.content, generatorContext.svgFactory)
 
     companion object {
         fun url(section: Section): String {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
@@ -8,9 +8,7 @@ fun FlowContent.diagram(viewModel: DiagramViewModel) {
         figure {
             style = "width: min(100%, ${viewModel.diagramWidthInPixels}px);"
 
-            unsafe {
-                +viewModel.svg
-            }
+            rawHtml(viewModel.svg)
             figcaption {
                 +viewModel.name
                 +" ["

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
@@ -4,26 +4,28 @@ import kotlinx.html.*
 import nl.avisi.structurizr.site.generatr.site.model.DiagramViewModel
 
 fun FlowContent.diagram(viewModel: DiagramViewModel) {
-    val diagramWidthInPixels = "viewBox=\"\\d+ \\d+ (\\d+) \\d+\"".toRegex()
-        .find(viewModel.svg)
-        ?.let { it.groupValues[1].toInt() }
-        ?: throw IllegalStateException("No viewBox attribute found in SVG!")
+    if (viewModel.svg != null)
+        figure {
+            style = "width: min(100%, ${viewModel.diagramWidthInPixels}px);"
 
-    figure {
-        style = "width: min(100%, ${diagramWidthInPixels}px);"
-
-        unsafe {
-            +viewModel.svg
+            unsafe {
+                +viewModel.svg
+            }
+            figcaption {
+                +viewModel.name
+                +" ["
+                a(href = viewModel.svgLocation.relativeHref) { +"svg" }
+                +"|"
+                a(href = viewModel.pngLocation.relativeHref) { +"png" }
+                +"|"
+                a(href = viewModel.pumlLocation.relativeHref) { +"puml" }
+                +"]"
+            }
         }
-        figcaption {
-            +viewModel.name
-            +" ["
-            a(href = viewModel.svgLocation.relativeHref) { +"svg" }
-            +"|"
-            a(href = viewModel.pngLocation.relativeHref) { +"png" }
-            +"|"
-            a(href = viewModel.pumlLocation.relativeHref) { +"puml" }
-            +"]"
+    else
+        div(classes = "notification is-danger") {
+            +"No view with key"
+            span(classes = "has-text-weight-bold") { +" ${viewModel.key} " }
+            +"found!"
         }
-    }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/HomePage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/HomePage.kt
@@ -6,7 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.HomePageViewModel
 fun HTML.homePage(viewModel: HomePageViewModel) {
     page(viewModel) {
         contentDiv {
-            markdown(viewModel, viewModel.content)
+            rawHtml(viewModel.content)
         }
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Markdown.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Markdown.kt
@@ -43,6 +43,7 @@ private fun markdownToHtml(pageViewModel: PageViewModel, markdownViewModel: Mark
 
     return Jsoup.parse(html)
         .apply { body().transformEmbeddedDiagramElements(pageViewModel, markdownViewModel.svgFactory) }
+        .body()
         .html()
 }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/RawHtml.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/RawHtml.kt
@@ -1,0 +1,13 @@
+package nl.avisi.structurizr.site.generatr.site.views
+
+import kotlinx.html.FlowContent
+import kotlinx.html.div
+import kotlinx.html.unsafe
+
+fun FlowContent.rawHtml(html: String) {
+    div {
+        unsafe {
+            +html
+        }
+    }
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDecisionPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDecisionPage.kt
@@ -5,6 +5,6 @@ import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemDecisionPageV
 
 fun HTML.softwareSystemDecisionPage(viewModel: SoftwareSystemDecisionPageViewModel) {
     softwareSystemPage(viewModel) {
-        markdown(viewModel, viewModel.content)
+        rawHtml(viewModel.content)
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemHomePage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemHomePage.kt
@@ -6,7 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemHomePageViewM
 
 fun HTML.softwareSystemHomePage(viewModel: SoftwareSystemHomePageViewModel) {
     softwareSystemPage(viewModel) {
-        markdown(viewModel, viewModel.content)
+        rawHtml(viewModel.content)
         if (viewModel.hasProperties) {
             h2 { +"Properties" }
             table(viewModel.propertiesTable)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionPage.kt
@@ -5,6 +5,6 @@ import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemSectionPageVi
 
 fun HTML.softwareSystemSectionPage(viewModel: SoftwareSystemSectionPageViewModel) {
     softwareSystemPage(viewModel) {
-        markdown(viewModel, viewModel.content)
+        rawHtml(viewModel.content)
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/WorkspaceDecisionPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/WorkspaceDecisionPage.kt
@@ -6,7 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.WorkspaceDecisionPageViewMo
 fun HTML.workspaceDecisionPage(viewModel: WorkspaceDecisionPageViewModel) {
     page(viewModel) {
         contentDiv {
-            markdown(viewModel, viewModel.content)
+            rawHtml(viewModel.content)
         }
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/WorkspaceDocumentationSectionPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/WorkspaceDocumentationSectionPage.kt
@@ -6,7 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.WorkspaceDocumentationSecti
 fun HTML.workspaceDocumentationSectionPage(viewModel: WorkspaceDocumentationSectionPageViewModel) {
     page(viewModel) {
         contentDiv {
-            markdown(viewModel, viewModel.content)
+            rawHtml(viewModel.content)
         }
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModelTest.kt
@@ -23,7 +23,7 @@ class HomePageViewModelTest : ViewModelTest() {
         val viewModel = HomePageViewModel(generatorContext)
 
         assertThat(viewModel.content)
-            .isEqualTo(MarkdownViewModel(DEFAULT_HOMEPAGE_CONTENT, svgFactory))
+            .isEqualTo(markdownToHtml(viewModel, DEFAULT_HOMEPAGE_CONTENT, svgFactory))
     }
 
     @Test
@@ -35,7 +35,7 @@ class HomePageViewModelTest : ViewModelTest() {
         val viewModel = HomePageViewModel(generatorContext)
 
         assertThat(viewModel.content)
-            .isEqualTo(MarkdownViewModel("Section content", svgFactory))
+            .isEqualTo(markdownToHtml(viewModel, "Section content", svgFactory))
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtmlTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtmlTest.kt
@@ -1,0 +1,75 @@
+package nl.avisi.structurizr.site.generatr.site.model
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+class MarkdownToHtmlTest : ViewModelTest() {
+
+    @Test
+    fun `translates markdown`() {
+        val generatorContext = generatorContext()
+        val viewModel = HomePageViewModel(generatorContext)
+
+        val html = markdownToHtml(
+            viewModel,
+            """
+                ## header
+                content
+            """.trimIndent(),
+            svgFactory
+        )
+
+        assertThat(html).isEqualTo(
+            """
+                <h2>header</h2>
+                <p>content</p>
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `embedded diagram`() {
+        val generatorContext = generatorContext()
+        val viewModel = HomePageViewModel(generatorContext)
+
+        val html = markdownToHtml(viewModel, "![System Landscape Diagram](embed:SystemLandscape)", svgFactory)
+
+        assertThat(html).isEqualTo(
+            """
+                <p>
+                 <div>
+                  <figure style="width: min(100%, 800px);">
+                   <div>
+                    <svg viewbox="0 0 800 900"></svg>
+                   </div>
+                   <figcaption>
+                    System Landscape Diagram [<a href="svg/SystemLandscape.svg">svg</a>|<a href="png/SystemLandscape.png">png</a>|<a href="puml/SystemLandscape.puml">puml</a>]
+                   </figcaption>
+                  </figure>
+                 </div></p>
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `embedded diagram key not found`() {
+        val generatorContext = generatorContext()
+        val viewModel = HomePageViewModel(generatorContext)
+
+        val html = markdownToHtml(viewModel, "![Diagram](embed:non-existing)") { _, _ ->
+            null
+        }
+
+        assertThat(html).isEqualTo(
+            """
+                <p>
+                 <div>
+                  <div class="notification is-danger">
+                   No view with key<span class="has-text-weight-bold"> non-existing </span>found!
+                  </div>
+                 </div></p>
+            """.trimIndent()
+        )
+    }
+}

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModelTest.kt
@@ -29,15 +29,19 @@ class SoftwareSystemComponentPageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.diagrams).containsExactly(
             DiagramViewModel(
+                "component-1",
                 "Software system - Backend - Components",
-                "<svg></svg>",
+                """<svg viewBox="0 0 800 900"></svg>""",
+                800,
                 ImageViewModel(viewModel, "/svg/component-1.svg"),
                 ImageViewModel(viewModel, "/png/component-1.png"),
                 ImageViewModel(viewModel, "/puml/component-1.puml")
             ),
             DiagramViewModel(
+                "component-2",
                 "Software system - Backend - Components",
-                "<svg></svg>",
+                """<svg viewBox="0 0 800 900"></svg>""",
+                800,
                 ImageViewModel(viewModel, "/svg/component-2.svg"),
                 ImageViewModel(viewModel, "/png/component-2.png"),
                 ImageViewModel(viewModel, "/puml/component-2.puml")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
@@ -28,15 +28,19 @@ class SoftwareSystemContainerPageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.diagrams).containsExactly(
             DiagramViewModel(
+                "container-1",
                 "Software system - Containers",
-                "<svg></svg>",
+                """<svg viewBox="0 0 800 900"></svg>""",
+                800,
                 ImageViewModel(viewModel, "/svg/container-1.svg"),
                 ImageViewModel(viewModel, "/png/container-1.png"),
                 ImageViewModel(viewModel, "/puml/container-1.puml")
             ),
             DiagramViewModel(
+                "container-2",
                 "Software system - Containers",
-                "<svg></svg>",
+                """<svg viewBox="0 0 800 900"></svg>""",
+                800,
                 ImageViewModel(viewModel, "/svg/container-2.svg"),
                 ImageViewModel(viewModel, "/png/container-2.png"),
                 ImageViewModel(viewModel, "/puml/container-2.puml")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
@@ -19,15 +19,19 @@ class SoftwareSystemContextPageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.diagrams).containsExactly(
             DiagramViewModel(
+                "context-1",
                 "Software system - System Context",
-                "<svg></svg>",
+                """<svg viewBox="0 0 800 900"></svg>""",
+                800,
                 ImageViewModel(viewModel, "/svg/context-1.svg"),
                 ImageViewModel(viewModel, "/png/context-1.png"),
                 ImageViewModel(viewModel, "/puml/context-1.puml")
             ),
             DiagramViewModel(
+                "context-2",
                 "Software system - System Context",
-                "<svg></svg>",
+                """<svg viewBox="0 0 800 900"></svg>""",
+                800,
                 ImageViewModel(viewModel, "/svg/context-2.svg"),
                 ImageViewModel(viewModel, "/png/context-2.png"),
                 ImageViewModel(viewModel, "/puml/context-2.puml")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModelTest.kt
@@ -33,6 +33,6 @@ class SoftwareSystemDecisionPageViewModelTest : ViewModelTest() {
         val decision = createDecision()
         val viewModel = SoftwareSystemDecisionPageViewModel(generatorContext, softwareSystem, decision)
 
-        assertThat(viewModel.content).isEqualTo(MarkdownViewModel(decision.content, svgFactory))
+        assertThat(viewModel.content).isEqualTo(markdownToHtml(viewModel, decision.content, svgFactory))
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
@@ -28,15 +28,19 @@ class SoftwareSystemDeploymentPageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.diagrams).containsExactly(
             DiagramViewModel(
+                "deployment-1",
                 "Software system - Deployment - Default",
-                "<svg></svg>",
+                """<svg viewBox="0 0 800 900"></svg>""",
+                800,
                 ImageViewModel(viewModel, "/svg/deployment-1.svg"),
                 ImageViewModel(viewModel, "/png/deployment-1.png"),
                 ImageViewModel(viewModel, "/puml/deployment-1.puml")
             ),
             DiagramViewModel(
+                "deployment-2",
                 "Software system - Deployment - Default",
-                "<svg></svg>",
+                """<svg viewBox="0 0 800 900"></svg>""",
+                800,
                 ImageViewModel(viewModel, "/svg/deployment-2.svg"),
                 ImageViewModel(viewModel, "/png/deployment-2.png"),
                 ImageViewModel(viewModel, "/puml/deployment-2.puml")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemHomePageViewModelTest.kt
@@ -28,8 +28,12 @@ class SoftwareSystemHomePageViewModelTest : ViewModelTest() {
         val viewModel = SoftwareSystemHomePageViewModel(generatorContext, softwareSystem)
 
         assertThat(viewModel.content)
-            .prop(MarkdownViewModel::markdown).isEqualTo(
-                "# Description${System.lineSeparator()}${softwareSystem.description}"
+            .isEqualTo(
+                markdownToHtml(
+                    viewModel,
+                    "# Description${System.lineSeparator()}${softwareSystem.description}",
+                    svgFactory
+                )
             )
     }
 
@@ -43,8 +47,8 @@ class SoftwareSystemHomePageViewModelTest : ViewModelTest() {
         val viewModel = SoftwareSystemHomePageViewModel(generatorContext, softwareSystem)
 
         assertThat(viewModel.content)
-            .prop(MarkdownViewModel::markdown).isEqualTo(
-                softwareSystem.documentation.sections.single().content
+            .isEqualTo(
+                markdownToHtml(viewModel, softwareSystem.documentation.sections.single().content, svgFactory)
             )
     }
 

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModelTest.kt
@@ -33,6 +33,6 @@ class SoftwareSystemSectionPageViewModelTest : ViewModelTest() {
         val section = createSection()
         val viewModel = SoftwareSystemSectionPageViewModel(generatorContext, softwareSystem, section)
 
-        assertThat(viewModel.content).isEqualTo(MarkdownViewModel(section.content, svgFactory))
+        assertThat(viewModel.content).isEqualTo(markdownToHtml(viewModel, section.content, svgFactory))
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
@@ -10,7 +10,7 @@ import java.time.ZoneId
 import java.util.*
 
 abstract class ViewModelTest {
-    protected val svgFactory = { _: String, _: String -> "<svg></svg>" }
+    protected val svgFactory = { _: String, _: String -> """<svg viewBox="0 0 800 900"></svg>""" }
 
     protected fun generatorContext(
         workspaceName: String = "workspace name",

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModelTest.kt
@@ -28,6 +28,6 @@ class WorkspaceDecisionPageViewModelTest : ViewModelTest() {
         val decision = createDecision()
         val viewModel = WorkspaceDecisionPageViewModel(generatorContext(), decision)
 
-        assertThat(viewModel.content).isEqualTo(MarkdownViewModel(decision.content, svgFactory))
+        assertThat(viewModel.content).isEqualTo(markdownToHtml(viewModel, decision.content, svgFactory))
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDocumentationSectionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDocumentationSectionPageViewModelTest.kt
@@ -38,6 +38,6 @@ class WorkspaceDocumentationSectionPageViewModelTest : ViewModelTest() {
         val section = createSection()
         val viewModel = WorkspaceDocumentationSectionPageViewModel(generatorContext, section)
 
-        assertThat(viewModel.content).isEqualTo(MarkdownViewModel(section.content, svgFactory))
+        assertThat(viewModel.content).isEqualTo(markdownToHtml(viewModel, section.content, svgFactory))
     }
 }


### PR DESCRIPTION
Re-use the diagram view when rendering an embedded diagram in a markdown. 

Also handle non-existing diagram keys in markdowns. This fixes https://github.com/avisi-cloud/structurizr-site-generatr/issues/93