### PR TITLE
Move EditorConfig comment to separate line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,8 @@ charset = utf-8
 # indent_size = 2
 # indent_style = tab
 insert_final_newline = true
-max_line_length = 120  # supported in only some editors; instead use prettier.printWidth
+# supported in only some editors; instead use prettier.printWidth
+max_line_length = 120
 trim_trailing_whitespace = true
 
 [*.{markdown,md,mdx}]


### PR DESCRIPTION
From https://editorconfig.org/#file-format-details "Comments should go on their own lines."

As a side effect, this prevents an exception in the IntelliJ Ktlint extension which otherwise interprets 120 as a string.
Granted, the extension itself should handle this more elegantly...