### PR TITLE
Redirect to software system home on hidden tabs

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
@@ -3,9 +3,26 @@ package nl.avisi.structurizr.site.generatr
 import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
 
 val Model.includedSoftwareSystems: List<SoftwareSystem>
     get() = softwareSystems.filter { it.includedSoftwareSystem }
 
 val SoftwareSystem.includedSoftwareSystem
-    get () = this.location != Location.External
+    get() = this.location != Location.External
+
+fun SoftwareSystem.hasDecisions() = documentation.decisions.isNotEmpty()
+
+fun SoftwareSystem.hasDocumentationSections() = documentation.sections.size >= 2
+
+fun ViewSet.hasSystemContextViews(softwareSystem: SoftwareSystem) =
+    systemContextViews.any { it.softwareSystem == softwareSystem }
+
+fun ViewSet.hasContainerViews(softwareSystem: SoftwareSystem) =
+    containerViews.any { it.softwareSystem == softwareSystem }
+
+fun ViewSet.hasComponentViews(softwareSystem: SoftwareSystem) =
+    componentViews.any { it.softwareSystem == softwareSystem }
+
+fun ViewSet.hasDeploymentViews(softwareSystem: SoftwareSystem) =
+    deploymentViews.any { it.softwareSystem == softwareSystem }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -66,7 +66,6 @@ fun generateSite(
 private fun deleteOldHashes(exportDir: File) = exportDir.walk().filter { it.extension == "md5" }
     .forEach { it.delete() }
 
-
 private fun copyAssets(assetsDir: File, exportDir: File) {
     assetsDir.copyRecursively(exportDir, overwrite = true)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModel.kt
@@ -1,6 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.hasComponentViews
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemComponentPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
@@ -9,4 +10,5 @@ class SoftwareSystemComponentPageViewModel(generatorContext: GeneratorContext, s
         .filter { it.softwareSystem == softwareSystem }
         .sortedBy { it.key }
         .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
+    val visible = generatorContext.workspace.views.hasComponentViews(softwareSystem)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModel.kt
@@ -1,6 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.hasContainerViews
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemContainerPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
@@ -9,4 +10,5 @@ class SoftwareSystemContainerPageViewModel(generatorContext: GeneratorContext, s
         .filter { it.softwareSystem == softwareSystem }
         .sortedBy { it.key }
         .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
+    val visible = generatorContext.workspace.views.hasContainerViews(softwareSystem)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModel.kt
@@ -1,6 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.hasSystemContextViews
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemContextPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
@@ -9,4 +10,5 @@ class SoftwareSystemContextPageViewModel(generatorContext: GeneratorContext, sof
         .filter { it.softwareSystem == softwareSystem }
         .sortedBy { it.key }
         .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
+    val visible = generatorContext.workspace.views.hasSystemContextViews(softwareSystem)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionsPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionsPageViewModel.kt
@@ -1,6 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.hasDecisions
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemDecisionsPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
@@ -8,4 +9,5 @@ class SoftwareSystemDecisionsPageViewModel(generatorContext: GeneratorContext, s
     val decisionsTable = createDecisionsTableViewModel(softwareSystem.documentation.decisions) {
         "$url/${it.id}"
     }
+    val visible = softwareSystem.hasDecisions()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModel.kt
@@ -1,6 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.hasDeploymentViews
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemDeploymentPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
@@ -9,4 +10,5 @@ class SoftwareSystemDeploymentPageViewModel(generatorContext: GeneratorContext, 
         .filter { it.softwareSystem == softwareSystem }
         .sortedBy { it.key }
         .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
+    val visible = generatorContext.workspace.views.hasDeploymentViews(softwareSystem)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemPageViewModel.kt
@@ -1,6 +1,12 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.hasComponentViews
+import nl.avisi.structurizr.site.generatr.hasContainerViews
+import nl.avisi.structurizr.site.generatr.hasDecisions
+import nl.avisi.structurizr.site.generatr.hasDeploymentViews
+import nl.avisi.structurizr.site.generatr.hasDocumentationSections
+import nl.avisi.structurizr.site.generatr.hasSystemContextViews
 import nl.avisi.structurizr.site.generatr.normalize
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
@@ -30,12 +36,12 @@ open class SoftwareSystemPageViewModel(
             get() = when (tab) {
                 Tab.HOME -> true
                 Tab.DEPENDENCIES -> true
-                Tab.SYSTEM_CONTEXT -> generatorContext.workspace.views.systemContextViews.any { it.softwareSystem == softwareSystem }
-                Tab.CONTAINER -> generatorContext.workspace.views.containerViews.any { it.softwareSystem == softwareSystem }
-                Tab.COMPONENT -> generatorContext.workspace.views.componentViews.any { it.softwareSystem == softwareSystem }
-                Tab.DEPLOYMENT -> generatorContext.workspace.views.deploymentViews.any { it.softwareSystem == softwareSystem }
-                Tab.DECISIONS -> softwareSystem.documentation.decisions.isNotEmpty()
-                Tab.SECTIONS -> softwareSystem.documentation.sections.size >= 2
+                Tab.SYSTEM_CONTEXT -> generatorContext.workspace.views.hasSystemContextViews(softwareSystem)
+                Tab.CONTAINER -> generatorContext.workspace.views.hasContainerViews(softwareSystem)
+                Tab.COMPONENT -> generatorContext.workspace.views.hasComponentViews(softwareSystem)
+                Tab.DEPLOYMENT -> generatorContext.workspace.views.hasDeploymentViews(softwareSystem)
+                Tab.DECISIONS -> softwareSystem.hasDecisions()
+                Tab.SECTIONS -> softwareSystem.hasDocumentationSections()
             }
     }
 
@@ -50,7 +56,7 @@ open class SoftwareSystemPageViewModel(
         TabViewModel(Tab.DEPLOYMENT),
         TabViewModel(Tab.DEPENDENCIES),
         TabViewModel(Tab.DECISIONS, exactLink = false),
-        TabViewModel(Tab.SECTIONS, exactLink = false),
+        TabViewModel(Tab.SECTIONS, exactLink = false)
     )
 
     val description: String = softwareSystem.description

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModel.kt
@@ -1,6 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.hasDocumentationSections
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemSectionsPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
@@ -8,4 +9,5 @@ class SoftwareSystemSectionsPageViewModel(generatorContext: GeneratorContext, so
     val sectionsTable = createSectionsTableViewModel(softwareSystem.documentation.sections) {
         "$url/${it.order}"
     }
+    val visible = softwareSystem.hasDocumentationSections()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/RedirectUpPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/RedirectUpPage.kt
@@ -1,0 +1,19 @@
+package nl.avisi.structurizr.site.generatr.site.views
+
+import kotlinx.html.HTML
+import kotlinx.html.body
+import kotlinx.html.head
+import kotlinx.html.meta
+import kotlinx.html.title
+
+fun HTML.redirectUpPage() {
+    attributes["lang"] = "en"
+    head {
+        meta {
+            httpEquiv = "refresh"
+            content = "0; url=../"
+        }
+        title { +"Structurizr site generatr" }
+    }
+    body()
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemComponentPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemComponentPage.kt
@@ -4,9 +4,12 @@ import kotlinx.html.HTML
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemComponentPageViewModel
 
 fun HTML.softwareSystemComponentPage(viewModel: SoftwareSystemComponentPageViewModel) {
-    softwareSystemPage(viewModel) {
-        viewModel.diagrams.forEach {
-            diagram(it)
+    if (viewModel.visible)
+        softwareSystemPage(viewModel) {
+            viewModel.diagrams.forEach {
+                diagram(it)
+            }
         }
-    }
+    else
+        redirectUpPage()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemContainerPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemContainerPage.kt
@@ -4,9 +4,12 @@ import kotlinx.html.HTML
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemContainerPageViewModel
 
 fun HTML.softwareSystemContainerPage(viewModel: SoftwareSystemContainerPageViewModel) {
-    softwareSystemPage(viewModel) {
-        viewModel.diagrams.forEach {
-            diagram(it)
+    if (viewModel.visible)
+        softwareSystemPage(viewModel) {
+            viewModel.diagrams.forEach {
+                diagram(it)
+            }
         }
-    }
+    else
+        redirectUpPage()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemContextPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemContextPage.kt
@@ -4,9 +4,12 @@ import kotlinx.html.HTML
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemContextPageViewModel
 
 fun HTML.softwareSystemContextPage(viewModel: SoftwareSystemContextPageViewModel) {
-    softwareSystemPage(viewModel) {
-        viewModel.diagrams.forEach {
-            diagram(it)
+    if (viewModel.visible)
+        softwareSystemPage(viewModel) {
+            viewModel.diagrams.forEach {
+                diagram(it)
+            }
         }
-    }
+    else
+        redirectUpPage()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDecisionsPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDecisionsPage.kt
@@ -4,7 +4,10 @@ import kotlinx.html.HTML
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemDecisionsPageViewModel
 
 fun HTML.softwareSystemDecisionsPage(viewModel: SoftwareSystemDecisionsPageViewModel) {
-    softwareSystemPage(viewModel) {
-        table(viewModel.decisionsTable)
-    }
+    if (viewModel.visible)
+        softwareSystemPage(viewModel) {
+            table(viewModel.decisionsTable)
+        }
+    else
+        redirectUpPage()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDeploymentPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDeploymentPage.kt
@@ -4,9 +4,12 @@ import kotlinx.html.HTML
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemDeploymentPageViewModel
 
 fun HTML.softwareSystemDeploymentPage(viewModel: SoftwareSystemDeploymentPageViewModel) {
-    softwareSystemPage(viewModel) {
-        viewModel.diagrams.forEach {
-            diagram(it)
+    if (viewModel.visible)
+        softwareSystemPage(viewModel) {
+            viewModel.diagrams.forEach {
+                diagram(it)
+            }
         }
-    }
+    else
+        redirectUpPage()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionsPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionsPage.kt
@@ -4,7 +4,10 @@ import kotlinx.html.HTML
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemSectionsPageViewModel
 
 fun HTML.softwareSystemSectionsPage(viewModel: SoftwareSystemSectionsPageViewModel) {
-    softwareSystemPage(viewModel) {
-        table(viewModel.sectionsTable)
-    }
+    if (viewModel.visible)
+        softwareSystemPage(viewModel) {
+            table(viewModel.sectionsTable)
+        }
+    else
+        redirectUpPage()
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModelTest.kt
@@ -3,6 +3,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import com.structurizr.model.SoftwareSystem
 import kotlin.test.Test
 
@@ -47,5 +48,15 @@ class SoftwareSystemComponentPageViewModelTest : ViewModelTest() {
                 ImageViewModel(viewModel, "/puml/component-2.puml")
             )
         )
+    }
+
+    @Test
+    fun `hidden view`() {
+        val viewModel = SoftwareSystemComponentPageViewModel(
+            generatorContext,
+            generatorContext.workspace.model.addSoftwareSystem("Software system 2")
+        )
+
+        assertThat(viewModel.visible).isFalse()
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
@@ -3,6 +3,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import com.structurizr.model.SoftwareSystem
 import kotlin.test.Test
 
@@ -46,5 +47,15 @@ class SoftwareSystemContainerPageViewModelTest : ViewModelTest() {
                 ImageViewModel(viewModel, "/puml/container-2.puml")
             )
         )
+    }
+
+    @Test
+    fun `hidden view`() {
+        val viewModel = SoftwareSystemContainerPageViewModel(
+            generatorContext,
+            generatorContext.workspace.model.addSoftwareSystem("Software system 2")
+        )
+
+        assertThat(viewModel.visible).isFalse()
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
@@ -2,6 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
 import assertk.assertions.containsExactly
+import assertk.assertions.isFalse
 import com.structurizr.model.SoftwareSystem
 import kotlin.test.Test
 
@@ -37,5 +38,15 @@ class SoftwareSystemContextPageViewModelTest : ViewModelTest() {
                 ImageViewModel(viewModel, "/puml/context-2.puml")
             )
         )
+    }
+
+    @Test
+    fun `hidden view`() {
+        val viewModel = SoftwareSystemContextPageViewModel(
+            generatorContext,
+            generatorContext.workspace.model.addSoftwareSystem("Software system 2")
+        )
+
+        assertThat(viewModel.visible).isFalse()
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionsPageViewModelTest.kt
@@ -2,6 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import nl.avisi.structurizr.site.generatr.normalize
 import kotlin.test.Test
 
@@ -29,5 +30,15 @@ class SoftwareSystemDecisionsPageViewModelTest : ViewModelTest() {
                     "/${softwareSystem.name.normalize()}/decisions/1"
                 }
             )
+    }
+
+    @Test
+    fun `hidden view`() {
+        val viewModel = SoftwareSystemDecisionsPageViewModel(
+            generatorContext,
+            generatorContext.workspace.model.addSoftwareSystem("Software system 2")
+        )
+
+        assertThat(viewModel.visible).isFalse()
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
@@ -3,6 +3,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import com.structurizr.model.SoftwareSystem
 import kotlin.test.Test
 
@@ -46,5 +47,15 @@ class SoftwareSystemDeploymentPageViewModelTest : ViewModelTest() {
                 ImageViewModel(viewModel, "/puml/deployment-2.puml")
             )
         )
+    }
+
+    @Test
+    fun `hidden view`() {
+        val viewModel = SoftwareSystemDeploymentPageViewModel(
+            generatorContext,
+            generatorContext.workspace.model.addSoftwareSystem("Software system 2")
+        )
+
+        assertThat(viewModel.visible).isFalse()
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModelTest.kt
@@ -2,6 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import nl.avisi.structurizr.site.generatr.normalize
 import kotlin.test.Test
 
@@ -30,5 +31,15 @@ class SoftwareSystemSectionsPageViewModelTest : ViewModelTest() {
                     "/${softwareSystem.name.normalize()}/sections/2"
                 }
             )
+    }
+
+    @Test
+    fun `hidden view`() {
+        val viewModel = SoftwareSystemSectionsPageViewModel(
+            generatorContext,
+            generatorContext.workspace.model.addSoftwareSystem("Software system 2")
+        )
+
+        assertThat(viewModel.visible).isFalse()
     }
 }


### PR DESCRIPTION
The tabs for context, components etc. are conditionally visible. Redirect to the software systems home (one level up in the url path) when visiting a page that is not visible.