### PR TITLE
feat: append slash to URLs to avoid 301 redirects

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
@@ -53,7 +53,7 @@ class C4PlantUmlExporterWithElementLinks(
         this is SoftwareSystem && this.includedSoftwareSystem && this != view?.softwareSystem
 
     private fun setElementUrl(element: Element) {
-        val path = "/${element.name.normalize()}/context/".asUrlRelativeTo(url)
+        val path = "/${element.name.normalize()}/context/".asUrlToDirectory(url)
         element.url = "${TEMP_URI}$path"
     }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
@@ -3,7 +3,7 @@ package nl.avisi.structurizr.site.generatr.site
 import java.nio.file.Path
 import kotlin.io.path.relativeTo
 
-fun String.asUrlRelativeTo(otherUrl: String) =
+fun String.asUrlRelativeTo(otherUrl: String, appendSlash: Boolean = true) =
     if (otherUrl == this) "."
     else Path.of(this)
-        .relativeTo(Path.of(otherUrl)).toString()
+        .relativeTo(Path.of(otherUrl)).toString() + if (appendSlash) "/" else ""

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
@@ -3,7 +3,13 @@ package nl.avisi.structurizr.site.generatr.site
 import java.nio.file.Path
 import kotlin.io.path.relativeTo
 
-fun String.asUrlRelativeTo(otherUrl: String, appendSlash: Boolean = true) =
+fun String.asUrlToFile(otherUrl: String) =
     if (otherUrl == this) "."
     else Path.of(this)
-        .relativeTo(Path.of(otherUrl)).toString() + if (appendSlash) "/" else ""
+        .relativeTo(Path.of(otherUrl)).toString()
+
+fun String.asUrlToDirectory(otherUrl: String) =
+        if (otherUrl == this) "."
+        else Path.of(this)
+                .relativeTo(Path.of(otherUrl)).toString() + "/"
+

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModel.kt
@@ -1,11 +1,11 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
-import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
+import nl.avisi.structurizr.site.generatr.site.asUrlToDirectory
 
 data class BranchHomeLinkViewModel(
     private val pageViewModel: PageViewModel,
     private val branchName: String
 ) {
     val title get() = branchName
-    val relativeHref get() = HomePageViewModel.url().asUrlRelativeTo(pageViewModel.url) + "../$branchName"
+    val relativeHref get() = HomePageViewModel.url().asUrlToDirectory(pageViewModel.url) + "../$branchName"
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModel.kt
@@ -7,5 +7,5 @@ data class BranchHomeLinkViewModel(
     private val branchName: String
 ) {
     val title get() = branchName
-    val relativeHref get() = HomePageViewModel.url().asUrlRelativeTo(pageViewModel.url) + "/../$branchName"
+    val relativeHref get() = HomePageViewModel.url().asUrlRelativeTo(pageViewModel.url) + "../$branchName"
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewModel.kt
@@ -3,5 +3,5 @@ package nl.avisi.structurizr.site.generatr.site.model
 import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
 
 data class ImageViewModel(val pageViewModel: PageViewModel, val href: String) {
-    val relativeHref get() = href.asUrlRelativeTo(pageViewModel.url)
+    val relativeHref get() = href.asUrlRelativeTo(pageViewModel.url, appendSlash = false)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewModel.kt
@@ -1,7 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
-import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
+import nl.avisi.structurizr.site.generatr.site.asUrlToFile
 
 data class ImageViewModel(val pageViewModel: PageViewModel, val href: String) {
-    val relativeHref get() = href.asUrlRelativeTo(pageViewModel.url, appendSlash = false)
+    val relativeHref get() = href.asUrlToFile(pageViewModel.url)
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/LinkViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/LinkViewModel.kt
@@ -1,6 +1,6 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
-import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
+import nl.avisi.structurizr.site.generatr.site.asUrlToDirectory
 
 data class LinkViewModel(
     private val pageViewModel: PageViewModel,
@@ -8,7 +8,7 @@ data class LinkViewModel(
     val href: String,
     val exact: Boolean = true
 ) {
-    val relativeHref get() = href.asUrlRelativeTo(pageViewModel.url)
+    val relativeHref get() = href.asUrlToDirectory(pageViewModel.url)
     val active get() = if (exact) isHrefOfContainingPage else isChildHrefOfContainingPage
 
     private val isHrefOfContainingPage get() = href == pageViewModel.url

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtml.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtml.kt
@@ -46,7 +46,7 @@ private class CustomLinkResolver(private val pageViewModel: PageViewModel) : Lin
             return link
 
         return link.withStatus(LinkStatus.VALID)
-            .withUrl("/${link.url.dropWhile { it == '/' }}".asUrlRelativeTo(pageViewModel.url))
+            .withUrl("/${link.url.dropWhile { it == '/' }}".asUrlRelativeTo(pageViewModel.url, appendSlash = false))
     }
 
     class Factory(private val viewModel: PageViewModel) : LinkResolverFactory {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtml.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtml.kt
@@ -12,7 +12,7 @@ import com.vladsch.flexmark.util.ast.Node
 import com.vladsch.flexmark.util.data.MutableDataSet
 import kotlinx.html.div
 import kotlinx.html.stream.createHTML
-import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
+import nl.avisi.structurizr.site.generatr.site.asUrlToFile
 import nl.avisi.structurizr.site.generatr.site.views.diagram
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
@@ -46,7 +46,7 @@ private class CustomLinkResolver(private val pageViewModel: PageViewModel) : Lin
             return link
 
         return link.withStatus(LinkStatus.VALID)
-            .withUrl("/${link.url.dropWhile { it == '/' }}".asUrlRelativeTo(pageViewModel.url, appendSlash = false))
+            .withUrl("/${link.url.dropWhile { it == '/' }}".asUrlToFile(pageViewModel.url))
     }
 
     class Factory(private val viewModel: PageViewModel) : LinkResolverFactory {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/AutoReloading.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/AutoReloading.kt
@@ -1,13 +1,13 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
 import kotlinx.html.*
-import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
+import nl.avisi.structurizr.site.generatr.site.asUrlToFile
 import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
 
 fun HEAD.autoReloadScript(viewModel: PageViewModel) {
     script(
         type = ScriptType.textJavaScript,
-        src = "../" + "/auto-reload.js".asUrlRelativeTo(viewModel.url, appendSlash = false)
+        src = "../" + "/auto-reload.js".asUrlToFile(viewModel.url)
     ) { }
 }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/AutoReloading.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/AutoReloading.kt
@@ -7,7 +7,7 @@ import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
 fun HEAD.autoReloadScript(viewModel: PageViewModel) {
     script(
         type = ScriptType.textJavaScript,
-        src = "../" + "/auto-reload.js".asUrlRelativeTo(viewModel.url)
+        src = "../" + "/auto-reload.js".asUrlRelativeTo(viewModel.url, appendSlash = false)
     ) { }
 }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -1,7 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
 import kotlinx.html.*
-import nl.avisi.structurizr.site.generatr.site.asUrlRelativeTo
+import nl.avisi.structurizr.site.generatr.site.asUrlToFile
 import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
 
 fun HTML.page(viewModel: PageViewModel, block: DIV.() -> Unit) {
@@ -20,7 +20,7 @@ private fun HTML.headFragment(viewModel: PageViewModel) {
         link(rel = "stylesheet", href = "https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css")
         link(
             rel = "stylesheet",
-            href = "../" + "/style.css".asUrlRelativeTo(viewModel.url, appendSlash = false)
+            href = "../" + "/style.css".asUrlToFile(viewModel.url)
         )
 
         if (viewModel.includeAutoReloading)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -20,7 +20,7 @@ private fun HTML.headFragment(viewModel: PageViewModel) {
         link(rel = "stylesheet", href = "https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css")
         link(
             rel = "stylesheet",
-            href = "../" + "/style.css".asUrlRelativeTo(viewModel.url)
+            href = "../" + "/style.css".asUrlRelativeTo(viewModel.url, appendSlash = false)
         )
 
         if (viewModel.includeAutoReloading)

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
@@ -54,7 +54,7 @@ class C4PlantUmlExporterWithElementLinksTest {
         assertThat(diagram.definition.withoutHeaderAndFooter()).isEqualTo(
             """
             System(System1, "System 1", "", ${'$'}tags="")
-            System(System2, "System 2", "", ${'$'}tags="")[[../system-2/context]]
+            System(System2, "System 2", "", ${'$'}tags="")[[../system-2/context/]]
 
             Rel_D(System2, System1, "uses", ${'$'}tags="")
             """.trimIndent()
@@ -71,7 +71,7 @@ class C4PlantUmlExporterWithElementLinksTest {
         assertThat(diagram.definition.withoutHeaderAndFooter()).isEqualTo(
             """
             System(System1, "System 1", "", ${'$'}tags="")
-            System(System2, "System 2", "", ${'$'}tags="")[[../../system-2/context]]
+            System(System2, "System 2", "", ${'$'}tags="")[[../../system-2/context/]]
 
             Rel_D(System2, System1, "uses", ${'$'}tags="")
             """.trimIndent()

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/LinkViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/LinkViewModelTest.kt
@@ -52,6 +52,6 @@ class LinkViewModelTest : ViewModelTest() {
     fun `relative href`() {
         val pageViewModel = pageViewModel("/some-page/some-subpage")
         val viewModel = LinkViewModel(pageViewModel, "Some other page", "/some-other-page")
-        assertThat(viewModel.relativeHref).isEqualTo("../../some-other-page")
+        assertThat(viewModel.relativeHref).isEqualTo("../../some-other-page/")
     }
 }


### PR DESCRIPTION
Hey,

Thanks for helping me with the last PR @dirkgroot @jp7677. One of the problems that I lately stumble upon is that generated URLs are mostly without appended slash on end i.e.:
```
../e-mail-system
../mainframe-banking-system
```


This creates a problem because in most HTTP servers serving static files by default, they are issuing HTTP 301 REDIRECT from `../e-mail-system` to `../e-mail-system/`. This is visible on the example website.
<img width="1190" alt="Screenshot 2023-01-18 at 18 45 03" src="https://user-images.githubusercontent.com/759579/213255710-b4706fe4-320f-46a7-bb58-813e4b4cc32a.png">

That would be fine, but if you are under Nginx by default, it is `port_in_redirect on;` which changes ports. Also, when working via some proxy (i.e. via VS Code Live Server), those redirects are affecting hostname and ports.

To prevent that, this PR is setting up correct URLs that aren't forcing redirects on the most popular HTTP servers/proxies.