### PR TITLE
Switch to kotlin-stdlib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.5")
 
     implementation("org.eclipse.jgit:org.eclipse.jgit:6.4.0.202211300538-r")


### PR DESCRIPTION
This is the way to go with Kotlin 1.8
See https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target