### PR TITLE
Support header branding

### DIFF
--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -156,6 +156,8 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
     views {
         properties {
             "c4plantuml.elementProperties" "true"
+            "structurizr.style.colors.primary" "#485fc7"
+            "structurizr.style.colors.secondary" "#ffffff"
         }
 
         systemlandscape "SystemLandscape" {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -60,6 +60,7 @@ fun generateSite(
 
     deleteOldHashes(exportDir)
     if (assetsDir != null) copyAssets(assetsDir, File(exportDir, currentBranch))
+    generateStyle(generatorContext, exportDir)
     generateHtmlFiles(generatorContext, exportDir)
 }
 
@@ -68,6 +69,29 @@ private fun deleteOldHashes(exportDir: File) = exportDir.walk().filter { it.exte
 
 private fun copyAssets(assetsDir: File, exportDir: File) {
     assetsDir.copyRecursively(exportDir, overwrite = true)
+}
+
+private fun generateStyle(context: GeneratorContext, exportDir: File) {
+    val configuration = context.workspace.views.configuration.properties
+    val primary = configuration.getOrDefault("structurizr.style.colors.primary", "#333333")
+    val secondary = configuration.getOrDefault("structurizr.style.colors.secondary", "#cccccc")
+
+    val file = File(exportDir, "style-branding.css")
+    val content = """
+        .navbar .has-site-branding {
+            background-color: $primary!important;
+            color: $secondary!important;
+        }
+        .navbar .has-site-branding::after {
+            border-color: $secondary!important;
+        }
+        .menu .has-site-branding a.is-active {
+            color: $secondary!important;
+            background-color: $primary!important;
+        }
+    """.trimIndent()
+
+    file.writeText(content)
 }
 
 private fun generateHtmlFiles(context: GeneratorContext, exportDir: File) {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Menu.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Menu.kt
@@ -22,7 +22,7 @@ private fun ASIDE.softwareSystemsSection(items: List<LinkViewModel>) {
 }
 
 private fun ASIDE.menuItemLinks(items: List<LinkViewModel>) {
-    ul(classes = "menu-list") {
+    ul(classes = "menu-list has-site-branding") {
         li {
             items.forEach {
                 link(it)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -22,6 +22,10 @@ private fun HTML.headFragment(viewModel: PageViewModel) {
             rel = "stylesheet",
             href = "../" + "/style.css".asUrlToFile(viewModel.url)
         )
+        link(
+            rel = "stylesheet",
+            href = "../" + "/style-branding.css".asUrlToFile(viewModel.url)
+        )
 
         if (viewModel.includeAutoReloading)
             autoReloadScript(viewModel)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/PageHeader.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/PageHeader.kt
@@ -5,17 +5,17 @@ import nl.avisi.structurizr.site.generatr.site.model.HeaderBarViewModel
 import nl.avisi.structurizr.site.generatr.site.model.LinkViewModel
 
 fun BODY.pageHeader(viewModel: HeaderBarViewModel) {
-    nav(classes = "navbar is-dark") {
+    nav(classes = "navbar") {
         role = "navigation"
         attributes["aria-label"] = "main navigation"
 
-        div(classes = "navbar-brand") {
+        div(classes = "navbar-brand has-site-branding") {
             navbarLink(viewModel.titleLink)
         }
-        div(classes = "navbar-menu") {
+        div(classes = "navbar-menu has-site-branding") {
             div(classes = "navbar-end") {
                 div(classes = "navbar-item has-dropdown is-hoverable") {
-                    a(classes = "navbar-link has-text-grey-light") {
+                    a(classes = "navbar-link has-site-branding") {
                         +viewModel.currentBranch
                     }
                     div(classes = "navbar-dropdown is-right") {
@@ -44,6 +44,6 @@ private fun DIV.navbarLink(viewModel: LinkViewModel) {
         classes = "navbar-item",
         href = viewModel.relativeHref
     ) {
-        span(classes = "has-text-weight-semibold") { +viewModel.title }
+        span(classes = "has-text-weight-semibold has-site-branding") { +viewModel.title }
     }
 }


### PR DESCRIPTION
Generate a stylesheet containing colors from custom properties from the
view configuration. This allows a more customized branding of the header
and the menu.

Fall back to the current grey if no custom branding is specified.