### PR TITLE
Fix branch link from home page

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
@@ -3,13 +3,10 @@ package nl.avisi.structurizr.site.generatr.site
 import java.nio.file.Path
 import kotlin.io.path.relativeTo
 
+fun String.asUrlToDirectory(otherUrl: String) = "${this.asUrlToFile(otherUrl)}/"
+
 fun String.asUrlToFile(otherUrl: String) =
     if (otherUrl == this) "."
     else Path.of(this)
         .relativeTo(Path.of(otherUrl)).toString()
-
-fun String.asUrlToDirectory(otherUrl: String) =
-        if (otherUrl == this) "./"
-        else Path.of(this)
-                .relativeTo(Path.of(otherUrl)).toString() + "/"
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
@@ -9,7 +9,7 @@ fun String.asUrlToFile(otherUrl: String) =
         .relativeTo(Path.of(otherUrl)).toString()
 
 fun String.asUrlToDirectory(otherUrl: String) =
-        if (otherUrl == this) "."
+        if (otherUrl == this) "./"
         else Path.of(this)
                 .relativeTo(Path.of(otherUrl)).toString() + "/"
 

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModelTest.kt
@@ -5,14 +5,10 @@ import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
 class BranchHomeLinkViewModelTest : ViewModelTest() {
-    private val pageViewModel = object : PageViewModel(generatorContext()) {
-        override val url: String = "/master/decisions/1"
-        override val pageSubTitle: String = "subtitle"
-    }
 
     @Test
     fun `title is branch name`() {
-        val viewModel = BranchHomeLinkViewModel(pageViewModel, "branch-1")
+        val viewModel = BranchHomeLinkViewModel(pageViewModel(), "branch-1")
 
         assertThat(viewModel.title)
             .isEqualTo("branch-1")
@@ -20,9 +16,17 @@ class BranchHomeLinkViewModelTest : ViewModelTest() {
 
     @Test
     fun `relative href to`() {
-        val viewModel = BranchHomeLinkViewModel(pageViewModel, "branch-1")
+        val viewModel = BranchHomeLinkViewModel(pageViewModel("/master/decisions/1"), "branch-1")
 
         assertThat(viewModel.relativeHref)
             .isEqualTo("../../../../branch-1")
+    }
+
+    @Test
+    fun `relative href from home`() {
+        val viewModel = BranchHomeLinkViewModel(pageViewModel("/"), "master")
+
+        assertThat(viewModel.relativeHref)
+            .isEqualTo("./../master")
     }
 }


### PR DESCRIPTION
Use './' instead '.' to avoid having three dots as a result when the current url is the same as the branch url.