### PR TITLE
Remove Home prefix for homepage title

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModel.kt
@@ -4,7 +4,7 @@ import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 import org.intellij.lang.annotations.Language
 
 class HomePageViewModel(generatorContext: GeneratorContext) : PageViewModel(generatorContext) {
-    override val pageSubTitle = "Home"
+    override val pageSubTitle = if (generatorContext.workspace.name.isNotBlank()) "" else "Home"
     override val url = url()
 
     val content = markdownToHtml(

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -3,9 +3,11 @@ package nl.avisi.structurizr.site.generatr.site.model
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
-    val pageTitle by lazy {
-        if (generatorContext.workspace.name.isNotBlank())
+    val pageTitle: String by lazy {
+        if (pageSubTitle.isNotBlank() && generatorContext.workspace.name.isNotBlank())
             "$pageSubTitle | ${generatorContext.workspace.name}"
+        else if (generatorContext.workspace.name.isNotBlank())
+            generatorContext.workspace.name
         else
             pageSubTitle
     }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/HomePageViewModelTest.kt
@@ -49,23 +49,23 @@ class HomePageViewModelTest : ViewModelTest() {
 
     @Test
     fun `page title with workspace name`() {
-        val generatorContext = generatorContext("this is a workspace")
+        val generatorContext = generatorContext("Workspace name")
         val viewModel = HomePageViewModel(generatorContext)
 
-        assertThat(viewModel.pageTitle).isEqualTo("Home | this is a workspace")
+        assertThat(viewModel.pageTitle).isEqualTo("Workspace name")
     }
 
     @Test
     fun `header bar`() {
-        val generatorContext = generatorContext("this is a workspace")
+        val generatorContext = generatorContext("Workspace name")
         val viewModel = HomePageViewModel(generatorContext)
 
-        assertThat(viewModel.headerBar.titleLink.title).isEqualTo("this is a workspace")
+        assertThat(viewModel.headerBar.titleLink.title).isEqualTo("Workspace name")
     }
 
     @Test
     fun menu() {
-        val generatorContext = generatorContext("this is a workspace")
+        val generatorContext = generatorContext("Workspace name")
         val viewModel = HomePageViewModel(generatorContext)
 
         assertThat(viewModel.menu.generalItems[0].active).isTrue()

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModelTest.kt
@@ -1,0 +1,13 @@
+package nl.avisi.structurizr.site.generatr.site.model
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+class PageViewModelTest : ViewModelTest() {
+
+    @Test
+    fun `page title`() {
+        assertThat(pageViewModel().pageTitle).isEqualTo("Some page | Workspace name")
+    }
+}

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ViewModelTest.kt
@@ -13,7 +13,7 @@ abstract class ViewModelTest {
     protected val svgFactory = { _: String, _: String -> """<svg viewBox="0 0 800 900"></svg>""" }
 
     protected fun generatorContext(
-        workspaceName: String = "workspace name",
+        workspaceName: String = "Workspace name",
         branches: List<String> = listOf("main"),
         currentBranch: String = "main",
         version: String = "1.0.0"


### PR DESCRIPTION
Do this only when we have a workspace name.

Let me know what you think. In my opinion highlighting that the home page is 'Home' looks overly verbose, esp when bookmarking the page. 