### PR TITLE
Fix diagram exists check

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -66,12 +66,14 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
             val ms = measureTimeMillis {
                 broadcast("site-updating")
                 val workspace = createStructurizrWorkspace(File(workspaceFile))
+
+                println("Generating idex page...")
+                generateRedirectingIndexPage(File(siteDir), branch)
+                println("Copying assets...")
+                copySiteWideAssets(File(siteDir))
                 println("Generating diagrams...")
                 generateDiagrams(workspace, exportDir)
-
                 println("Generating site...")
-                copySiteWideAssets(File(siteDir))
-                generateRedirectingIndexPage(File(siteDir), branch)
                 generateSite(
                     "0.0.0",
                     workspace,

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
@@ -25,9 +25,9 @@ fun generateDiagrams(workspace: Workspace, exportDir: File) {
             val plantUMLFile = File(pumlDir, "${diagram.key}.puml")
             if (!plantUMLFile.exists() || plantUMLFile.readText() != diagram.definition) {
                 println("${diagram.key}...")
-                saveAsPUML(diagram, plantUMLFile)
                 saveAsSvg(diagram, svgDir)
                 saveAsPng(diagram, pngDir)
+                saveAsPUML(diagram, plantUMLFile)
             } else {
                 println("${diagram.key} UP-TO-DATE")
             }
@@ -43,8 +43,8 @@ fun generateDiagramWithElementLinks(view: View, url: String, exportDir: File): S
     val name = "${diagram.key}-${view.key}"
     val plantUMLFile = File(pumlDir, "$name.puml")
     if (!plantUMLFile.exists() || plantUMLFile.readText() != diagram.definition) {
-        saveAsPUML(diagram, plantUMLFile)
         saveAsSvg(diagram, svgDir, name)
+        saveAsPUML(diagram, plantUMLFile)
     } else {
         println("$name UP-TO-DATE")
     }


### PR DESCRIPTION
Since we use the existence of the puml file as up-to-date check, we should write this after all other formats have been written.

This prevents a FileNotFoundException during concurrent page generation when the puml was already generated, thus we assumed that the SVG had also been generated, but in fact the SVG wasn't yet there.

This should fix https://github.com/avisi-cloud/structurizr-site-generatr/issues/151