### PR TITLE
Create export directory before writing into it

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -60,7 +60,7 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
 
     private fun updateSite() {
         val branch = "master"
-        val exportDir = File(siteDir, branch)
+        val exportDir = File(siteDir, branch).apply { mkdirs() }
 
         try {
             val ms = measureTimeMillis {


### PR DESCRIPTION
This fixes a FileNotFoundException when the export directory didn't exists before serving the site in live mode.

Same as https://github.com/avisi-cloud/structurizr-site-generatr/blob/main/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt#L58

I guess before https://github.com/avisi-cloud/structurizr-site-generatr/pull/154 this was created implicitly somewhere when generating the diagrams.