### PR TITLE
Updated Dependencies Page

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModel.kt
@@ -4,7 +4,9 @@ import com.structurizr.model.Relationship
 import com.structurizr.model.SoftwareSystem
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
-class SoftwareSystemDependenciesPageViewModel(generatorContext: GeneratorContext,private val softwareSystem: SoftwareSystem
+class SoftwareSystemDependenciesPageViewModel(
+    generatorContext: GeneratorContext,
+    private val softwareSystem: SoftwareSystem
 ) : SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DEPENDENCIES) {
 
     val dependenciesInboundTable = TableViewModel.create {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModel.kt
@@ -37,8 +37,7 @@ class SoftwareSystemDependenciesPageViewModel(generatorContext: GeneratorContext
         headerRow(
             headerCell("System"),
             headerCell("Description"),
-            headerCell("Technology"),
-            headerCell("Tags")
+            headerCell("Technology")
         )
     }
 
@@ -46,8 +45,7 @@ class SoftwareSystemDependenciesPageViewModel(generatorContext: GeneratorContext
         bodyRow(
             softwareSystemDependencyCell(relationship.source as SoftwareSystem),
             cell(relationship.description),
-            cell(relationship.technology),
-            cell(relationship.tags.replace("Relationship,","").replace("Relationship",""))
+            cell(relationship.technology)
         )
     }
 
@@ -55,8 +53,7 @@ class SoftwareSystemDependenciesPageViewModel(generatorContext: GeneratorContext
         bodyRow(
             softwareSystemDependencyCell(relationship.destination as SoftwareSystem),
             cell(relationship.description),
-            cell(relationship.technology),
-            cell(relationship.tags.replace("Relationship,","").replace("Relationship",""))
+            cell(relationship.technology)
         )
     }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModel.kt
@@ -4,40 +4,59 @@ import com.structurizr.model.Relationship
 import com.structurizr.model.SoftwareSystem
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
-class SoftwareSystemDependenciesPageViewModel(
-    generatorContext: GeneratorContext,
-    private val softwareSystem: SoftwareSystem
+class SoftwareSystemDependenciesPageViewModel(generatorContext: GeneratorContext,private val softwareSystem: SoftwareSystem
 ) : SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DEPENDENCIES) {
-    val dependenciesTable = TableViewModel.create {
-        header()
 
-        incomingAndOutgoingRelationships.forEach {
-            bodyRow(it)
-        }
+    val dependenciesInboundTable = TableViewModel.create {
+        header()
+        incomingRelationships.forEach {inboundBodyRow(it)}
     }
 
-    private val incomingAndOutgoingRelationships
+    val dependenciesOutboundTable = TableViewModel.create {
+        header()
+        outgoingRelationships.forEach {outboundBodyRow(it)}
+    }
+
+    private val incomingRelationships
+        get() = generatorContext.workspace.model.relationships.asSequence()
+            .filter { it.destination == softwareSystem }
+            .plus(softwareSystem.relationships)
+            .filter { it.source is SoftwareSystem && it.destination is SoftwareSystem}
+            .filter { it.destination == softwareSystem}
+            .sortedBy { it.source.name.lowercase() }
+
+    private val outgoingRelationships
         get() = generatorContext.workspace.model.relationships.asSequence()
             .filter { it.destination == softwareSystem }
             .plus(softwareSystem.relationships)
             .filter { it.source is SoftwareSystem && it.destination is SoftwareSystem }
-            .sortedBy { it.source.name.lowercase() }
+            .filter { it.source == softwareSystem}
+            .sortedBy { it.destination.name.lowercase() }
 
     private fun TableViewModel.TableViewInitializerContext.header() {
         headerRow(
-            headerCell("Source"),
+            headerCell("System"),
             headerCell("Description"),
-            headerCell("Destination"),
-            headerCell("Technology")
+            headerCell("Technology"),
+            headerCell("Tags")
         )
     }
 
-    private fun TableViewModel.TableViewInitializerContext.bodyRow(relationship: Relationship) {
+    private fun TableViewModel.TableViewInitializerContext.inboundBodyRow(relationship: Relationship) {
         bodyRow(
             softwareSystemDependencyCell(relationship.source as SoftwareSystem),
             cell(relationship.description),
+            cell(relationship.technology),
+            cell(relationship.tags.replace("Relationship,","").replace("Relationship",""))
+        )
+    }
+
+    private fun TableViewModel.TableViewInitializerContext.outboundBodyRow(relationship: Relationship) {
+        bodyRow(
             softwareSystemDependencyCell(relationship.destination as SoftwareSystem),
-            cell(relationship.technology)
+            cell(relationship.description),
+            cell(relationship.technology),
+            cell(relationship.tags.replace("Relationship,","").replace("Relationship",""))
         )
     }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDependenciesPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDependenciesPage.kt
@@ -1,10 +1,14 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
 import kotlinx.html.HTML
+import kotlinx.html.h2
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemDependenciesPageViewModel
 
 fun HTML.softwareSystemDependenciesPage(viewModel: SoftwareSystemDependenciesPageViewModel) {
     softwareSystemPage(viewModel) {
-        table(viewModel.dependenciesTable)
+        h2 { +"Inbound" }
+        table(viewModel.dependenciesInboundTable)
+        h2 { +"Outbound" }
+        table(viewModel.dependenciesOutboundTable)
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
@@ -44,7 +44,6 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
                     ),
                     cell("Uses SOAP"),
                     cell("SOAP"),
-                    cell("")
                 )
             }
         )
@@ -65,7 +64,6 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
                     ),
                     cell("Uses REST"),
                     cell("REST"),
-                    cell("")
                 )
             }
         )
@@ -141,7 +139,6 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
             headerCell("System"),
             headerCell("Description"),
             headerCell("Technology"),
-            headerCell("Tags")
         )
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
@@ -96,6 +96,8 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
         val viewModel = SoftwareSystemDependenciesPageViewModel(generatorContext, softwareSystem1)
         assertThat(viewModel.dependenciesInboundTable.bodyRows[0].columns[0])
             .isEqualTo(TableViewModel.TextCellViewModel("External system (External)", isHeader = true, greyText = true))
+        assertThat(viewModel.dependenciesOutboundTable.bodyRows[0].columns[0])
+            .isEqualTo(TableViewModel.TextCellViewModel("External system (External)", isHeader = true, greyText = true))
     }
 
     @Test


### PR DESCRIPTION
This PR introduces an updated dependencies page where the table has been split in to two tables, one for Inbound relationships and the other for Outbound relationships.

I've also added in a new column to show the tags that have been assigned to the relationship. The default tag of 'Relationship' is not shown in the column to make things a little neater.