### PR TITLE
Fixed SiteBranding CSS bug for generated sites

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -60,21 +60,22 @@ fun generateSite(
             ?.let { generateDiagramWithElementLinks(it, url, exportDir) }
     }
 
-    deleteOldHashes(exportDir)
-    if (assetsDir != null) copyAssets(assetsDir, File(exportDir, currentBranch))
-    generateStyle(generatorContext, exportDir)
-    generateHtmlFiles(generatorContext, exportDir)
+    val branchDir = File(exportDir, currentBranch)
+
+    deleteOldHashes(branchDir)
+    if (assetsDir != null) copyAssets(assetsDir, branchDir)
+    generateStyle(generatorContext, branchDir)
+    generateHtmlFiles(generatorContext, branchDir)
 }
 
-private fun deleteOldHashes(exportDir: File) = exportDir.walk().filter { it.extension == "md5" }
+private fun deleteOldHashes(branchDir: File) = branchDir.walk().filter { it.extension == "md5" }
     .forEach { it.delete() }
 
-private fun copyAssets(assetsDir: File, exportDir: File) {
-    assetsDir.copyRecursively(exportDir, overwrite = true)
+private fun copyAssets(assetsDir: File, branchDir: File) {
+    assetsDir.copyRecursively(branchDir, overwrite = true)
 }
 
-private fun generateStyle(context: GeneratorContext, exportDir: File) {
-    val branchDir = File(exportDir, context.currentBranch)
+private fun generateStyle(context: GeneratorContext, branchDir: File) {
     val configuration = context.workspace.views.configuration.properties
     val primary = configuration.getOrDefault("generatr.style.colors.primary", "#333333")
     val secondary = configuration.getOrDefault("generatr.style.colors.secondary", "#cccccc")
@@ -105,8 +106,7 @@ private fun generateStyle(context: GeneratorContext, exportDir: File) {
     file.writeText(content)
 }
 
-private fun generateHtmlFiles(context: GeneratorContext, exportDir: File) {
-    val branchDir = File(exportDir, context.currentBranch)
+private fun generateHtmlFiles(context: GeneratorContext, branchDir: File) {
     buildList {
         add { writeHtmlFile(branchDir, HomePageViewModel(context)) }
         add { writeHtmlFile(branchDir, WorkspaceDecisionsPageViewModel(context)) }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -74,11 +74,12 @@ private fun copyAssets(assetsDir: File, exportDir: File) {
 }
 
 private fun generateStyle(context: GeneratorContext, exportDir: File) {
+    val branchDir = File(exportDir, context.currentBranch)
     val configuration = context.workspace.views.configuration.properties
     val primary = configuration.getOrDefault("generatr.style.colors.primary", "#333333")
     val secondary = configuration.getOrDefault("generatr.style.colors.secondary", "#cccccc")
 
-    val file = File(exportDir, "style-branding.css")
+    val file = File(branchDir, "style-branding.css")
     val content = """
         .navbar .has-site-branding {
             background-color: $primary!important;

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -24,7 +24,7 @@ private fun HTML.headFragment(viewModel: PageViewModel) {
         )
         link(
             rel = "stylesheet",
-            href = "../" + "/style-branding.css".asUrlToFile(viewModel.url)
+            href = "./" + "/style-branding.css".asUrlToFile(viewModel.url)
         )
 
         if (viewModel.favicon.includeFavicon)


### PR DESCRIPTION
When using the 'generate' command the generation of the site-branding.css file was occurring before the workspace DSL had been read in to memory meaning that it was always using the defaults instead of any properties in the DSL.

I've moved the call to 'copySiteWideAssets' to after the DSL is read in for both the local workspace DSL and for repository based DSLs. In the case of a repository based DSL the copySiteWideAssets call is only done once on the default branch.

Fixes #219 