### PR TITLE
Fix "Invalid PlantUML generated" #221

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
@@ -67,7 +67,7 @@ class C4PlantUmlExporterWithElementLinks(
         element is Container && element.hasComponents
 
     private fun getUrlToComponentViews(element: Element?): String {
-        val path = "/${element?.parent?.name?.normalize()}/component/".asUrlToFile(url)
+        val path = "/${element?.parent?.name?.normalize()}/component/".asUrlToDirectory(url)
         return "$TEMP_URI$path"
     }
 

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinksTest.kt
@@ -87,7 +87,7 @@ class C4PlantUmlExporterWithElementLinksTest {
             """
             skinparam preserveAspectRatio meet
             System_Boundary("System1_boundary", "System 1", ${'$'}tags="") {
-              Container(System1.Container1, "Container 1", "", ${'$'}tags="")[[../system-1/component]]
+              Container(System1.Container1, "Container 1", "", ${'$'}tags="")[[../system-1/component/]]
             }
             """.trimIndent()
         )


### PR DESCRIPTION
Use `asUrlToDirectory` as target link for components

Fix for #221