### PR TITLE
Clear search results before adding actual results

### DIFF
--- a/src/main/resources/assets/js/search.js
+++ b/src/main/resources/assets/js/search.js
@@ -18,6 +18,7 @@ function search(terms) {
   });
 
   const div = document.getElementById('search-results');
+  clearResultElements(div);
 
   if (results.length === 0) {
     div.appendChild(createNoResultsElement());
@@ -25,6 +26,12 @@ function search(terms) {
     results.forEach(result => {
       div.appendChild(createResultElement(result));
     });
+  }
+}
+
+function clearResultElements(div) {
+  while (div.firstChild) {
+    div.removeChild(div.firstChild);
   }
 }
 


### PR DESCRIPTION
This hopefully fixes duplicated results in weird navigate-back scenarios.

Unfortunately I could not reproduce this with the example served on localhost, but is was very visible on our real site.