### PR TITLE
SupportActualMermaidSyntax

### DIFF
--- a/docs/example/workspace-docs/01-embedding-diagrams-and-images.md
+++ b/docs/example/workspace-docs/01-embedding-diagrams-and-images.md
@@ -34,3 +34,71 @@ directory, you can do that as follows:
 
 ![A nice picture](/pictures/nice-picture.png)
 
+### Embedding mermaid diagrams
+
+Structurizr Site Generatr is supporting mermaid diagrams in markdown pages using the actual mermaid.js version. Therefore every diagram type, supported by mermaid may be used in markdown documentation files.
+
+* flowchart
+* sequence diagram
+* class diagram
+* state diagram
+* entity-relationship diagram
+* user journey
+* gantt chart
+* pie chart
+* requirement diagram
+* and some more
+
+Please find the full list of supported chart types on [mermaid.js.org/intro](https://mermaid.js.org/intro/#diagram-types)
+
+#### Flowchart Diagram Example
+
+````markdown
+```mermaid
+graph TD;
+  A-->B;
+  A-->C;
+  B-->D;
+  C-->D;
+```
+````
+
+```mermaid
+graph TD;
+  A-->B;
+  A-->C;
+  B-->D;
+  C-->D;
+```
+
+#### Sequence Diagram Example
+
+````markdown
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop Healthcheck
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+```
+````
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop Healthcheck
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+```

--- a/docs/example/workspace-docs/02-markdown-features.md
+++ b/docs/example/workspace-docs/02-markdown-features.md
@@ -59,6 +59,7 @@ This will be rendered as
 Please see [GitLab flavored markdown features](https://docs.gitlab.com/ee/user/markdown.html?tab=Rendered+Markdown) for a detailed description.
 Unfortunately only the following features are supported by Flexmark markdown renderer, that is used here.
 
+<<<<<<< HEAD
 #### Mermaid diagram support
 
 Structurizr Site Generatr is using the actual mermaid.js version. Therefore every diagram type, supported by mermaid may be used in markdown documentation files.
@@ -128,6 +129,8 @@ sequenceDiagram
     Bob-->>John: Jolly good!
 ```
 
+=======
+>>>>>>> moved mermaid samples to Embedding diagrams page
 #### Multiline Block quote delimiters
 
 ```markdown

--- a/docs/example/workspace-docs/02-markdown-features.md
+++ b/docs/example/workspace-docs/02-markdown-features.md
@@ -61,7 +61,7 @@ Unfortunately only the following features are supported by Flexmark markdown ren
 
 #### Mermaid diagram support
 
-structurizr-site-generatr is using the actual mermaid.js version. Therefore every diagram type, supported by mermaid may be used in markdown documentation files.
+Structurizr Site Generatr is using the actual mermaid.js version. Therefore every diagram type, supported by mermaid may be used in markdown documentation files.
 
 * flowchart
 * sequence diagram

--- a/docs/example/workspace-docs/02-markdown-features.md
+++ b/docs/example/workspace-docs/02-markdown-features.md
@@ -61,6 +61,23 @@ Unfortunately only the following features are supported by Flexmark markdown ren
 
 #### Mermaid diagram support
 
+structurizr-site-generatr is using the actual mermaid.js version. Therefore every diagram type, supported by mermaid may be used in markdown documentation files.
+
+* flowchart
+* sequence diagram
+* class diagram
+* state diagram
+* entity-relationship diagram
+* user journey
+* gantt chart
+* pie chart
+* requirement diagram
+* some more
+
+Please find the full list of supported chart types on [mermaid.js.org/intro](https://mermaid.js.org/intro/#diagram-types)
+
+##### Flowchart Diagram Example
+
 ````markdown
 ```mermaid
 graph TD;
@@ -77,6 +94,38 @@ graph TD;
   A-->C;
   B-->D;
   C-->D;
+```
+
+##### Sequence Diagram Example
+
+````markdown
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop Healthcheck
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+```
+````
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop Healthcheck
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
 ```
 
 #### Multiline Block quote delimiters

--- a/docs/example/workspace-docs/02-markdown-features.md
+++ b/docs/example/workspace-docs/02-markdown-features.md
@@ -1,6 +1,31 @@
-## Markdown features
+## Extended markdown features
 
-This page showcases the ability to use extended markdown formating features in workspace documentation files.
+This page showcases the ability to use extended markdown formating features in workspace documentation files. The full list of available extensions to standard commonmark markdown features is documented in the flexmark wiki [Extensions page](https://github.com/vsch/flexmark-java/wiki/Extensions).
+
+Most of these extended features have to be activated in your architecture model as a property in workspace views.
+
+```DSL
+workspace {
+    ...
+    views {
+        ...
+        properties {
+            ...
+            // full list of available "generatr.markdown.flexmark.extensions"
+            // "Abbreviation,Admonition,AnchorLink,Aside,Attributes,Autolink,Definition,Emoji,EnumeratedReference,Footnotes,GfmIssues,GfmStrikethroughSubscript,GfmTaskList,GfmUsers,GitLab,Ins,Macros,MediaTags,ResizableImage,Superscript,Tables,TableOfContents,SimulatedTableOfContents,Typographic,WikiLinks,XWikiMacro,YAMLFrontMatter,YouTubeLink"
+            // see https://github.com/vsch/flexmark-java/wiki/Extensions
+            // ATTENTION:
+            // * "generatr.markdown.flexmark.extensions" values must be separated by comma
+            // * it's not possible to use "GitLab" and "ResizableImage" extensions together
+            // default behaviour, if no generatr.markdown.flexmark.extensions property is specified, is to load the Tables extension only
+            "generatr.markdown.flexmark.extensions" "Abbreviation,Admonition,AnchorLink,Attributes,Autolink,Definition,Emoji,Footnotes,GfmTaskList,GitLab,MediaTags,Tables,TableOfContents,Typographic"
+            ...
+        }
+        ...
+    }
+    ...
+}
+```
 
 ### TableOfContents
 
@@ -13,6 +38,14 @@ This page showcases the ability to use extended markdown formating features in w
 will render into
 
 [TOC]
+
+#### Usage info
+
+"TableOfContents" is an optional feature, that has to be activated in workspace views properties
+
+```DSL
+    "generatr.markdown.flexmark.extensions" "TableOfContents"
+```
 
 ### Render Tables
 
@@ -29,6 +62,14 @@ This will be rendered as
 | header1 | header2 |
 | ------- | ------- |
 | content | content |
+
+#### Usage info
+
+"Render Tables" is an optional feature, that is enabled by default. If other optional markdown features are activated in workspace views properties, than you have to ensure, that Tables is listed in the extension list as well.
+
+```DSL
+    "generatr.markdown.flexmark.extensions" "Tables"
+```
 
 ### Admonition Blocks
 
@@ -54,83 +95,19 @@ This will be rendered as
 !!! info "information"
     this is an additional information
 
+#### Usage info
+
+"Admonition Blocks" is an optional feature, that has to be activated in workspace views properties
+
+```DSL
+    "generatr.markdown.flexmark.extensions" "Admonition"
+```
+
 ### GitLab flavored markdown extensions
 
 Please see [GitLab flavored markdown features](https://docs.gitlab.com/ee/user/markdown.html?tab=Rendered+Markdown) for a detailed description.
 Unfortunately only the following features are supported by Flexmark markdown renderer, that is used here.
 
-<<<<<<< HEAD
-#### Mermaid diagram support
-
-Structurizr Site Generatr is using the actual mermaid.js version. Therefore every diagram type, supported by mermaid may be used in markdown documentation files.
-
-* flowchart
-* sequence diagram
-* class diagram
-* state diagram
-* entity-relationship diagram
-* user journey
-* gantt chart
-* pie chart
-* requirement diagram
-* some more
-
-Please find the full list of supported chart types on [mermaid.js.org/intro](https://mermaid.js.org/intro/#diagram-types)
-
-##### Flowchart Diagram Example
-
-````markdown
-```mermaid
-graph TD;
-  A-->B;
-  A-->C;
-  B-->D;
-  C-->D;
-```
-````
-
-```mermaid
-graph TD;
-  A-->B;
-  A-->C;
-  B-->D;
-  C-->D;
-```
-
-##### Sequence Diagram Example
-
-````markdown
-```mermaid
-sequenceDiagram
-    participant Alice
-    participant Bob
-    Alice->>John: Hello John, how are you?
-    loop Healthcheck
-        John->>John: Fight against hypochondria
-    end
-    Note right of John: Rational thoughts <br/>prevail!
-    John-->>Alice: Great!
-    John->>Bob: How about you?
-    Bob-->>John: Jolly good!
-```
-````
-
-```mermaid
-sequenceDiagram
-    participant Alice
-    participant Bob
-    Alice->>John: Hello John, how are you?
-    loop Healthcheck
-        John->>John: Fight against hypochondria
-    end
-    Note right of John: Rational thoughts <br/>prevail!
-    John-->>Alice: Great!
-    John->>Bob: How about you?
-    Bob-->>John: Jolly good!
-```
-
-=======
->>>>>>> moved mermaid samples to Embedding diagrams page
 #### Multiline Block quote delimiters
 
 ```markdown
@@ -198,11 +175,27 @@ This math is on a separate line using a ```` ```math ```` block:
 a^2+b^2=c^2
 ```
 
+#### Usage info
+
+"GitLab Flavored Markdown" is an optional feature, that has to be activated in workspace views properties
+
+```DSL
+    "generatr.markdown.flexmark.extensions" "GitLab"
+```
+
 ### AnchorLink
 
-Automatically adds anchor links to heading, using GitHub id generation algorithm
+Automatically adds anchor links to headings, using GitHub id generation algorithm
 
-### DefinitionLists
+#### Usage info
+
+"AnchorLink" is an optional feature, that has to be activated in workspace views properties
+
+```DSL
+    "generatr.markdown.flexmark.extensions" "AnchorLink"
+```
+
+### Definition Lists
 
 Converts definition syntax of Php Markdown Extra Definition List to `<dl></dl>` HTML and corresponding AST nodes.
 
@@ -215,6 +208,14 @@ Definition Term
 Definition Term
 : Definition of above term
 : Another definition of above term
+
+#### Usage info
+
+"Definition Lists" is an optional feature, that has to be activated in workspace views properties
+
+```DSL
+    "generatr.markdown.flexmark.extensions" "Definition"
+```
 
 ### Emoji
 
@@ -229,6 +230,14 @@ warning :warning:
 thumbsup :thumbsup:  
 calendar :calendar:  
 warning :warning:  
+
+#### Usage info
+
+"Emoji" is an optional feature, that has to be activated in workspace views properties
+
+```DSL
+    "generatr.markdown.flexmark.extensions" "Emoji"
+```
 
 ### GfmTaskList
 
@@ -257,3 +266,11 @@ will be rendered as
 1. [ ] Incomplete task
    1. [x] Sub-task 1
    1. [ ] Sub-task 3
+
+#### Usage info
+
+"GfmTaskList" is an optional feature, that has to be activated in workspace views properties
+
+```DSL
+    "generatr.markdown.flexmark.extensions" "GfmTaskList"
+```

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -170,9 +170,6 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
             // * it's not possible to use "GitLab" and "ResizableImage" extensions together
             // default behaviour, if no generatr.markdown.flexmark.extensions property is specified, is to load the Tables extension only
             "generatr.markdown.flexmark.extensions" "Abbreviation,Admonition,AnchorLink,Attributes,Autolink,Definition,Emoji,Footnotes,GfmTaskList,GitLab,MediaTags,Tables,TableOfContents,Typographic"
-
-             // default behaviour, if no is generatr.markdown.mermaid.enabled property i specified, is "true"
-            "generatr.markdown.mermaid.enabled" "true"
         }
 
         systemlandscape "SystemLandscape" {

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -170,6 +170,9 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
             // * it's not possible to use "GitLab" and "ResizableImage" extensions together
             // default behaviour, if no generatr.markdown.flexmark.extensions property is specified, is to load the Tables extension only
             "generatr.markdown.flexmark.extensions" "Abbreviation,Admonition,AnchorLink,Attributes,Autolink,Definition,Emoji,Footnotes,GfmTaskList,GitLab,MediaTags,Tables,TableOfContents,Typographic"
+
+             // default behaviour, if no is generatr.markdown.mermaid.enabled property i specified, is "true"
+            "generatr.markdown.mermaid.enabled" "true"
         }
 
         systemlandscape "SystemLandscape" {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -18,6 +18,7 @@ fun copySiteWideAssets(exportDir: File) {
     copySiteWideAsset(exportDir, "/js/auto-reload.js")
     copySiteWideAsset(exportDir, "/css/admonition.css")
     copySiteWideAsset(exportDir, "/js/admonition.js")
+    copySiteWideAsset(exportDir, "/js/reformat-mermaid.js")
 }
 
 private fun copySiteWideAsset(exportDir: File, asset: String) {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/FlexmarkConfig.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/FlexmarkConfig.kt
@@ -7,6 +7,7 @@ import com.vladsch.flexmark.util.data.DataHolder
 import com.vladsch.flexmark.util.data.MutableDataSet
 import com.vladsch.flexmark.ext.emoji.EmojiExtension
 import com.vladsch.flexmark.ext.emoji.EmojiImageType
+import com.vladsch.flexmark.ext.gitlab.GitLabExtension
 import com.vladsch.flexmark.parser.Parser
 
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
@@ -78,6 +79,9 @@ fun buildFlexmarkConfig(context: GeneratorContext): FlexmarkConfig {
 
     if (selectedExtensionMap.containsKey("Emoji")) {
         flexmarkOptions.set(EmojiExtension.USE_IMAGE_TYPE, EmojiImageType.UNICODE_ONLY)
+    }
+    if (selectedExtensionMap.containsKey("GitLab")) {
+        flexmarkOptions.set(GitLabExtension.RENDER_BLOCK_MERMAID, false)
     }
 
     return FlexmarkConfig(flexmarkExtensionString, selectedExtensionMap, flexmarkOptions)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -23,7 +23,6 @@ abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
     val includeKatex = flexmarkConfig.selectedExtensionMap.containsKey("GitLab")
 
     val configuration = generatorContext.workspace.views.configuration.properties
-    val includeMermaid = configuration.getOrDefault("generatr.markdown.mermaid.enabled", "true").toBoolean()
 
     abstract val url: String
     abstract val pageSubTitle: String

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -21,7 +21,9 @@ abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
     }
     val includeAdmonition = flexmarkConfig.selectedExtensionMap.containsKey("Admonition")
     val includeKatex = flexmarkConfig.selectedExtensionMap.containsKey("GitLab")
-    val includeMermaid = flexmarkConfig.selectedExtensionMap.containsKey("GitLab")
+
+    val configuration = generatorContext.workspace.views.configuration.properties
+    val includeMermaid = configuration.getOrDefault("generatr.markdown.mermaid.enabled", "true").toBoolean()
 
     abstract val url: String
     abstract val pageSubTitle: String

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/MarkdownExtension.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/MarkdownExtension.kt
@@ -55,7 +55,12 @@ fun HEAD.katexFonts() {
     }
 }
 
-fun BODY.mermaidScript() {
+fun BODY.mermaidScript(viewModel: PageViewModel) {
+    // Fix to support mermaid diagrams in markdown:
+    script(
+        type = ScriptType.textJavaScript,
+        src = "../" + "/reformat-mermaid.js".asUrlToFile(viewModel.url)
+    ) { }
     // Simple full example, how to include Mermaid: https://mermaid.js.org/config/usage.html#simple-full-example
     script(type = "module") {
         unsafe {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -64,7 +64,6 @@ private fun HTML.bodyFragment(viewModel: PageViewModel, block: DIV.() -> Unit) {
             updateSiteErrorHero()
         if (viewModel.includeAdmonition)
             markdownAdmonitionScript(viewModel)
-        if (viewModel.includeMermaid)
-            mermaidScript(viewModel)
+        mermaidScript(viewModel)
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -65,6 +65,6 @@ private fun HTML.bodyFragment(viewModel: PageViewModel, block: DIV.() -> Unit) {
         if (viewModel.includeAdmonition)
             markdownAdmonitionScript(viewModel)
         if (viewModel.includeMermaid)
-            mermaidScript()
+            mermaidScript(viewModel)
     }
 }

--- a/src/main/resources/assets/js/reformat-mermaid.js
+++ b/src/main/resources/assets/js/reformat-mermaid.js
@@ -1,0 +1,17 @@
+// solution from https://css-tricks.com/making-mermaid-diagrams-in-markdown/
+
+// select <pre class="mermaid"> _and_ <pre><code class="language-mermaid">
+document.querySelectorAll("pre.mermaid, pre>code.language-mermaid, div.mermaid").forEach($el => {
+    // if the second selector got a hit, reference the parent <pre>
+    if ($el.tagName === "CODE")
+      $el = $el.parentElement
+    // put the Mermaid contents in the expected <div class="mermaid">
+    // plus keep the original contents in a nice <details>
+    $el.outerHTML = `
+      <div class="mermaid">${$el.textContent}</div>
+      <details>
+        <summary>Diagram source</summary>
+        <pre>${$el.textContent}</pre>
+      </details>
+    `
+  })

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtmlTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtmlTest.kt
@@ -201,9 +201,48 @@ class MarkdownToHtmlTest : ViewModelTest() {
         assertThat(html).isEqualTo(
             """
             <h2>Mermaid</h2>
-            <div class="mermaid">
-             graph TD; A--&gt;B; A--&gt;C; B--&gt;D; C--&gt;D;
-            </div>
+            <pre><code class="language-mermaid">graph TD;
+            A--&gt;B;
+            A--&gt;C;
+            B--&gt;D;
+            C--&gt;D;
+            </code></pre>
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `translates mermaid graphings in markdown without extension property containing GitLab`() {
+        val generatorContext = generatorContext().apply {
+            workspace.views.configuration.addProperty("generatr.markdown.flexmark.extensions", "Admonition, Tables")
+        }
+        val viewModel = HomePageViewModel(generatorContext)
+
+        val html = markdownToHtml(
+            viewModel,
+            """
+                ## Mermaid
+
+                ```mermaid
+                graph TD;
+                A-->B;
+                A-->C;
+                B-->D;
+                C-->D;
+                ```
+            """.trimIndent(),
+            svgFactory
+        )
+
+        assertThat(html).isEqualTo(
+            """
+            <h2>Mermaid</h2>
+            <pre><code class="language-mermaid">graph TD;
+            A--&gt;B;
+            A--&gt;C;
+            B--&gt;D;
+            C--&gt;D;
+            </code></pre>
             """.trimIndent()
         )
     }


### PR DESCRIPTION
Support actual syntax for mermaid diagrams with line ending as statement limiter.
Currently semicolon has to be used as statement limiter on each line, otherwise a syntax error will be thrown by mermaid code.