### PR TITLE
List of branches will now only include good branches

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -115,7 +115,7 @@ class GenerateSiteCommand : Subcommand(
                 workspace,
                 assetsDir?.let { File(cloneDir, it) },
                 siteDir,
-                branchNames,
+                branchesToGenerate,
                 branch
             )
         }


### PR DESCRIPTION
List was set to show all detected/mentioned branch names instead of the filtered list causing invalid links for any branched that were not actually generated.