### PR TITLE
Fix to halt site generation if the default branch is not valid.

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -104,6 +104,10 @@ class GenerateSiteCommand : Subcommand(
 
         println("The following branches contain a valid Structurizr workspace: $branchesToGenerate")
 
+        if (!branchesToGenerate.contains(defaultBranch)) {
+            throw Exception("$defaultBranch does not contain a valid structurizr workspace. Site generation halted.")
+        }
+
         branchesToGenerate.forEach { branch ->
             println("Generating site for branch $branch")
             clonedRepository.checkoutBranch(branch)


### PR DESCRIPTION
When building multiple branches it is important that the default branch is working so that the site generator has a valid branch to redirect to when initially opened.

This bug fix will cause the site generator to halt with a runtime exception if the default branch is not a valid workspace dsl.