### PR TITLE
Restrict list of detected branches to remote only to avoid duplication

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ClonedRepository.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ClonedRepository.kt
@@ -3,7 +3,6 @@ package nl.avisi.structurizr.site.generatr
 import org.eclipse.jgit.api.CreateBranchCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.ListBranchCommand
-import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 import java.io.File
@@ -52,7 +51,7 @@ class ClonedRepository(
     }
 
     fun getBranchNames(excludeBranches: List<String>) =
-        Git(repo).branchList().setListMode(ListBranchCommand.ListMode.ALL).call()
+        Git(repo).branchList().setListMode(ListBranchCommand.ListMode.REMOTE).call()
             .map { it.name.toString().substringAfterLast("/") }
             .onEach { println("Found the following branch: $it") }
             .filter { it !in excludeBranches }


### PR DESCRIPTION
Fixes #265

List of branches will no longer include the locally clones branch of main/master which was causing that branch to show twice in the dropdown list.

also removed an unused import to clean up the file.