### PR TITLE
Support links between ADR's

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModel.kt
@@ -9,7 +9,12 @@ class SoftwareSystemDecisionPageViewModel(
 ) : SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DECISIONS) {
     override val url = url(softwareSystem, decision)
 
-    val content = markdownToHtml(this, decision.content, generatorContext.svgFactory)
+    val content = markdownToHtml(this, fixADRLinks(decision.content, softwareSystem), generatorContext.svgFactory)
+
+    private fun fixADRLinks(content: String, softwareSystem: SoftwareSystem) =
+        content.replace("\\[(.*)]\\(#(\\d+)\\)".toRegex()) {
+            "[${it.groupValues[1]}](${url(softwareSystem, Tab.DECISIONS)}/${it.groupValues[2]})"
+        }
 
     companion object {
         fun url(softwareSystem: SoftwareSystem, decision: Decision) =

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModel.kt
@@ -9,9 +9,9 @@ class SoftwareSystemDecisionPageViewModel(
 ) : SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DECISIONS) {
     override val url = url(softwareSystem, decision)
 
-    val content = markdownToHtml(this, fixADRLinks(decision.content, softwareSystem), generatorContext.svgFactory)
+    val content = markdownToHtml(this, transformADRLinks(decision.content, softwareSystem), generatorContext.svgFactory)
 
-    private fun fixADRLinks(content: String, softwareSystem: SoftwareSystem) =
+    private fun transformADRLinks(content: String, softwareSystem: SoftwareSystem) =
         content.replace("\\[(.*)]\\(#(\\d+)\\)".toRegex()) {
             "[${it.groupValues[1]}](${url(softwareSystem, Tab.DECISIONS)}/${it.groupValues[2]})"
         }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModel.kt
@@ -8,7 +8,12 @@ class WorkspaceDecisionPageViewModel(generatorContext: GeneratorContext, decisio
     override val url = url(decision)
     override val pageSubTitle: String = decision.title
 
-    val content = markdownToHtml(this, decision.content, generatorContext.svgFactory)
+    val content = markdownToHtml(this, fixADRLinks(decision.content), generatorContext.svgFactory)
+
+    private fun fixADRLinks(content: String) =
+        content.replace("\\[(.*)]\\(#(\\d+)\\)".toRegex()) {
+            "[${it.groupValues[1]}](decisions/${it.groupValues[2]})"
+        }
 
     companion object {
         fun url(decision: Decision) = "/decisions/${decision.id}"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModel.kt
@@ -8,9 +8,9 @@ class WorkspaceDecisionPageViewModel(generatorContext: GeneratorContext, decisio
     override val url = url(decision)
     override val pageSubTitle: String = decision.title
 
-    val content = markdownToHtml(this, fixADRLinks(decision.content), generatorContext.svgFactory)
+    val content = markdownToHtml(this, transformADRLinks(decision.content), generatorContext.svgFactory)
 
-    private fun fixADRLinks(content: String) =
+    private fun transformADRLinks(content: String) =
         content.replace("\\[(.*)]\\(#(\\d+)\\)".toRegex()) {
             "[${it.groupValues[1]}](decisions/${it.groupValues[2]})"
         }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDecisionPageViewModelTest.kt
@@ -3,6 +3,8 @@ package nl.avisi.structurizr.site.generatr.site.model
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import nl.avisi.structurizr.site.generatr.normalize
+import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemPageViewModel.Companion.url
+import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemPageViewModel.Tab
 import kotlin.test.Test
 
 class SoftwareSystemDecisionPageViewModelTest : ViewModelTest() {
@@ -25,7 +27,7 @@ class SoftwareSystemDecisionPageViewModelTest : ViewModelTest() {
         val viewModel = SoftwareSystemDecisionPageViewModel(generatorContext, softwareSystem, createDecision())
 
         assertThat(viewModel.tabs.single { it.link.active }.tab)
-            .isEqualTo(SoftwareSystemPageViewModel.Tab.DECISIONS)
+            .isEqualTo(Tab.DECISIONS)
     }
 
     @Test
@@ -34,5 +36,29 @@ class SoftwareSystemDecisionPageViewModelTest : ViewModelTest() {
         val viewModel = SoftwareSystemDecisionPageViewModel(generatorContext, softwareSystem, decision)
 
         assertThat(viewModel.content).isEqualTo(markdownToHtml(viewModel, decision.content, svgFactory))
+    }
+
+
+    @Test
+    fun `link to other ADR`() {
+        val decision = createDecision().apply {
+            content = """
+                Decision with [link to other ADR](#2).
+                [Web link](https://google.com)
+                [Internal link](#other-section)
+            """.trimIndent()
+        }
+        val viewModel = SoftwareSystemDecisionPageViewModel(generatorContext, softwareSystem, decision)
+
+        assertThat(viewModel.content).isEqualTo(
+            markdownToHtml(
+                viewModel, """
+                    Decision with [link to other ADR](${url(softwareSystem, Tab.DECISIONS)}/2).
+                    [Web link](https://google.com)
+                    [Internal link](#other-section)
+                """.trimIndent(),
+                svgFactory
+            )
+        )
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModelTest.kt
@@ -30,4 +30,27 @@ class WorkspaceDecisionPageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.content).isEqualTo(markdownToHtml(viewModel, decision.content, svgFactory))
     }
+
+    @Test
+    fun `link to other ADR`() {
+        val decision = createDecision().apply {
+            content = """
+                Decision with [link to other ADR](#2).
+                [Web link](https://google.com)
+                [Internal link](#other-section)
+            """.trimIndent()
+        }
+        val viewModel = WorkspaceDecisionPageViewModel(generatorContext(), decision)
+
+        assertThat(viewModel.content).isEqualTo(
+            markdownToHtml(
+                viewModel, """
+                    Decision with [link to other ADR](decisions/2).
+                    [Web link](https://google.com)
+                    [Internal link](#other-section)
+                """.trimIndent(),
+                svgFactory
+            )
+        )
+    }
 }


### PR DESCRIPTION
When importing ADR's, Structurizr automatically transforms links to other ADR's. This PR adds functionality to transform these transformed links into links that correctly link to the corresponding ADR. 

Fixes #260.

## Example

Assuming an existing ADR file named `0001-first-adr.md`, an ADR like this:

```markdown
# 2. Some ADR

[link to ADR 1](0001-first-adr.md)
```

will be transformed by Structurizr to:

```markdown
# 2. Some ADR

[link to ADR 1](#1)
```

The new functionality from this PR will in turn transfer this to the following in case of a workspace-level ADR:

```markdown
# 2. Some ADR

[link to ADR 1](decisions/1)
```

and to the following in case of an ADR for a software system named "Software System":

```markdown
# 2. Some ADR

[link to ADR 1](software-system/decisions/1)
```
