### PR TITLE
Print exception stack trace for bad branch

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -98,6 +98,7 @@ class GenerateSiteCommand : Subcommand(
                 true
             } catch (e: Exception) {
                 println("Bad Branch $branch")
+                e.printStackTrace()
                 false
             }
         }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -97,7 +97,7 @@ class GenerateSiteCommand : Subcommand(
                 createStructurizrWorkspace(workspaceFileInRepo)
                 true
             } catch (e: Exception) {
-                errorMessage = e.message ?: "Unknown error"
+                val errorMessage = e.message ?: "Unknown error"
                 println("Bad Branch $branch: $errorMessage")
                 false
             }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -97,8 +97,8 @@ class GenerateSiteCommand : Subcommand(
                 createStructurizrWorkspace(workspaceFileInRepo)
                 true
             } catch (e: Exception) {
-                println("Bad Branch $branch")
-                e.printStackTrace()
+                errorMessage = e.message ?: "Unknown error"
+                println("Bad Branch $branch: $errorMessage")
                 false
             }
         }


### PR DESCRIPTION
Print stack trace to help debug bad branches. Will help resolve https://github.com/avisi-cloud/structurizr-site-generatr/issues/286.