### PR TITLE
Fix regression bug to get branch names.

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ClonedRepository.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ClonedRepository.kt
@@ -52,7 +52,7 @@ class ClonedRepository(
 
     fun getBranchNames(excludeBranches: List<String>) =
         Git(repo).branchList().setListMode(ListBranchCommand.ListMode.REMOTE).call()
-            .map { it.name.toString().substringAfter("/") }
+            .map { it.name.toString().substringAfter("/remotes/origin/") }
             .onEach { println("Found the following branch: $it") }
             .filter { it !in excludeBranches }
 


### PR DESCRIPTION
Fixes the issue introduced to originally fix #289
I've tested this against my multi-branch repo and it is working as desired including a branch with a / in the name.