### PR TITLE
Revert commit "Fix stripping branch name"

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ClonedRepository.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ClonedRepository.kt
@@ -52,7 +52,7 @@ class ClonedRepository(
 
     fun getBranchNames(excludeBranches: List<String>) =
         Git(repo).branchList().setListMode(ListBranchCommand.ListMode.REMOTE).call()
-            .map { it.name.toString().substringAfter("/") }
+            .map { it.name.toString().substringAfterLast("/") }
             .onEach { println("Found the following branch: $it") }
             .filter { it !in excludeBranches }
 


### PR DESCRIPTION
This reverts https://github.com/avisi-cloud/structurizr-site-generatr/commit/b867cc9d7abc7d1b64ad6f2e1c5d3ccab60c049b

This commit created a regression when generating from git branches. See https://github.com/avisi-cloud/structurizr-site-generatr/discussions/342#discussioncomment-7381183