### PR TITLE
Ignore case in branch name comparator

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -143,5 +143,5 @@ class GenerateSiteCommand : Subcommand(
 fun branchComparator(defaultBranch: String) = Comparator<String> { a, b ->
     if (a == defaultBranch) -1
     else if (b == defaultBranch) 1
-    else a.compareTo(b)
+    else a.compareTo(b, ignoreCase = true)
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/BranchComparatorTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/BranchComparatorTest.kt
@@ -9,16 +9,16 @@ import org.junit.jupiter.api.TestFactory
 class BranchComparatorTest {
     @TestFactory
     fun `default branch first then by string`() = listOf(
-        listOf("a", "b", "main"),
-        listOf("a", "main", "b"),
-        listOf("b", "a", "main"),
-        listOf("b", "main", "a"),
-        listOf("main", "a", "b"),
-        listOf("main", "b", "a")
+        listOf("a", "B", "main"),
+        listOf("a", "main", "B"),
+        listOf("B", "a", "main"),
+        listOf("B", "main", "a"),
+        listOf("main", "a", "B"),
+        listOf("main", "B", "a"),
     ).map { branches ->
         DynamicTest.dynamicTest(branches.toString()) {
             assertThat(branches.sortedWith(branchComparator("main")))
-                .containsExactly("main", "a", "b")
+                .containsExactly("main", "a", "B")
         }
     }
 }


### PR DESCRIPTION
Minor fix to ignore the case in the branch comparator.