### PR TITLE
Create a new cache for each site generation

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
@@ -36,9 +36,12 @@ fun generateDiagrams(workspace: Workspace, exportDir: File) {
         }
 }
 
-private val diagramCache = ConcurrentHashMap<String, String>()
-
-fun generateDiagramWithElementLinks(workspace: Workspace, view: View, url: String): String {
+fun generateDiagramWithElementLinks(
+    workspace: Workspace,
+    view: View,
+    url: String,
+    diagramCache: ConcurrentHashMap<String, String>
+): String {
     val diagram = generatePlantUMLDiagramWithElementLinks(workspace, view, url)
 
     val name = "${diagram.key}-${view.key}"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -10,6 +10,7 @@ import java.io.File
 import java.math.BigInteger
 import java.nio.file.Path
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 
 fun copySiteWideAssets(exportDir: File) {
     copySiteWideAsset(exportDir, "/css/style.css")
@@ -62,8 +63,9 @@ fun generateSite(
     serving: Boolean = false
 ) {
     val generatorContext = GeneratorContext(version, workspace, branches, currentBranch, serving) { key, url ->
+        val diagramCache = ConcurrentHashMap<String, String>()
         workspace.views.views.singleOrNull { view -> view.key == key }
-            ?.let { generateDiagramWithElementLinks(workspace, it, url) }
+            ?.let { generateDiagramWithElementLinks(workspace, it, url, diagramCache) }
     }
 
     val branchDir = File(exportDir, currentBranch)


### PR DESCRIPTION
This resolves caching issues when generating for multiple branches or when serving continuously. There is probably a more elegant solution, but lets go with this since we have a kind-of broken release. 


PS: Apparently cache-invalidation is one of two hardest things in IT ;)