### PR TITLE
Identify external software systems by custom tag

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,3 +29,12 @@ indent_style = space
 [Dockerfile]
 # indent_size = 4
 indent_style = space
+
+[*.{kt,kts}]
+max_line_length = 160
+ij_kotlin_allow_trailing_comma_on_call_site = false
+ij_kotlin_allow_trailing_comma = false
+
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_argument-list-wrapping = disabled
+ktlint_standard_multiline_if_else = disabled

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ is generated from the example workspace in this repository.
 
 - Generate a static HTML site, based on a Structurizr DSL workspace.
 - Generates diagrams in SVG, PNG and PlantUML format, which can be viewed and downloaded from the generated site.
-- Easy browsing through the site by clicking on software system and container elements in the diagrams.
+- Easy browsing through the site by clicking on software system and container elements in the diagrams. Note that
+  external software systems are excluded from the menu. A software system is considered external when it lives outside
+  the (deprecated) enterprise boundary or when groups are used and the software system is outside of any group.   
 - Start a development server which generates a site, serves it and updates the site automatically whenever a file that's
   part of the Structurizr workspace changes.
 - Include documentation (in Markdown or AsciiDoc format) in the generated site. Both workspace level documentation and software
@@ -268,7 +270,7 @@ architecture model:
 
 
 See the included example for usage of some those properties in the
-[C4 architecture model example](https://github.com/avisi-cloud/structurizr-site-generatr/blob/main/docs/example/workspace.dsl#L159).
+[C4 architecture model example](https://github.com/avisi-cloud/structurizr-site-generatr/blob/main/docs/example/workspace.dsl#L163).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ is generated from the example workspace in this repository.
 - Generates diagrams in SVG, PNG and PlantUML format, which can be viewed and downloaded from the generated site.
 - Easy browsing through the site by clicking on software system and container elements in the diagrams. Note that
   external software systems are excluded from the menu. A software system is considered external when it lives outside
-  the (deprecated) enterprise boundary or when groups are used and the software system is outside of any group.   
+  the (deprecated) enterprise boundary or when it contains a specific tag, see [Customizing the generated website](#customizing-the-generated-website). 
 - Start a development server which generates a site, serves it and updates the site automatically whenever a file that's
   part of the Structurizr workspace changes.
 - Include documentation (in Markdown or AsciiDoc format) in the generated site. Both workspace level documentation and software
@@ -266,8 +266,8 @@ architecture model:
 | `generatr.search.language`              | Indexing/stemming language for the search index. See [Lunr language support](https://github.com/olivernn/lunr-languages)                                                                                                                                                                                                                         | `en`      | `nl`                                                 |
 | `generatr.markdown.flexmark.extensions` | Additional extensions to the markdown generator to add new markdown capabilities. [More Details](https://avisi-cloud.github.io/structurizr-site-generatr/main/extended-markdown-features/)                                                                                                                                                       | Tables    | `Tables,Admonition`                                  |
 | `generatr.svglink.target`               | Specifies the link target for element links in the exported svg                                                                                                                                                                                                                                                                                  | `_top`    | `_self`                                              |
-| `generatr.site.nestGroups`              | Will show software systems in the left side navigator in collapsable groups                                                                                                                                                                                                                                                                      | `false`   | `true`                                               |
-
+| `generatr.site.externalTag`             | Software systems containing this tag will be considered external                                                                                                                                                                                                                                                                                 |           |                                                      |
+| `generatr.site.nestGroups`              | Will show software systems in the left side navigator in collapsable ~~~~groups                                                                                                                                                                                                                                                                  | `false`   | `true`                                               |
 
 See the included example for usage of some those properties in the
 [C4 architecture model example](https://github.com/avisi-cloud/structurizr-site-generatr/blob/main/docs/example/workspace.dsl#L163).

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -9,11 +9,15 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
     !adrs workspace-adrs
 
     model {
+        properties {
+            "structurizr.groupSeparator" "/"
+        }
+
         customer = person "Personal Banking Customer" "A customer of the bank, with personal bank accounts." "Customer"
 
         acquirer = softwaresystem "Acquirer" "Facilitates PIN transactions for merchants." "External System"
 
-        enterprise "Big Bank plc" {
+        group "Big Bank plc" {
             supportStaff = person "Customer Service Staff" "Customer service staff within the bank." "Bank Staff" {
                 properties {
                     "Location" "Customer Services"
@@ -177,6 +181,8 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
             // * it's not possible to use "GitLab" and "ResizableImage" extensions together
             // default behaviour, if no generatr.markdown.flexmark.extensions property is specified, is to load the Tables extension only
             "generatr.markdown.flexmark.extensions" "Abbreviation,Admonition,AnchorLink,Attributes,Autolink,Definition,Emoji,Footnotes,GfmTaskList,GitLab,MediaTags,Tables,TableOfContents,Typographic"
+
+            "generatr.site.nestGroups" "false"
         }
 
         systemlandscape "SystemLandscape" {

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -182,6 +182,7 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
             // default behaviour, if no generatr.markdown.flexmark.extensions property is specified, is to load the Tables extension only
             "generatr.markdown.flexmark.extensions" "Abbreviation,Admonition,AnchorLink,Attributes,Autolink,Definition,Emoji,Footnotes,GfmTaskList,GitLab,MediaTags,Tables,TableOfContents,Typographic"
 
+            "generatr.site.externalTag" "External System"
             "generatr.site.nestGroups" "false"
         }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
@@ -1,25 +1,25 @@
 package nl.avisi.structurizr.site.generatr
 
+import com.structurizr.Workspace
 import com.structurizr.model.Container
 import com.structurizr.model.Location
-import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
 
-val Model.includedSoftwareSystems: List<SoftwareSystem>
-    get() = if (softwareSystems.any { it.group != null })
-        softwareSystems.filter { it.group != null }
-    else
-        softwareSystems.filter { it.location != Location.External }
-
-val Container.hasComponents
-    get() = this.components.isNotEmpty()
+val Workspace.includedSoftwareSystems: List<SoftwareSystem>
+    get() = model.softwareSystems.filter {
+        val externalTag = views.configuration.properties.getOrDefault("generatr.site.externalTag", null)
+        it.location != Location.External && if (externalTag != null) !it.tags.contains(externalTag) else true
+    }
 
 val SoftwareSystem.hasContainers
     get() = this.containers.isNotEmpty()
 
 val SoftwareSystem.includedProperties
     get() = this.properties.filterNot { (name, _) -> name == "structurizr.dsl.identifier" }
+
+val Container.hasComponents
+    get() = this.components.isNotEmpty()
 
 fun SoftwareSystem.hasDecisions() = documentation.decisions.isNotEmpty()
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
@@ -7,10 +7,10 @@ import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
 
 val Model.includedSoftwareSystems: List<SoftwareSystem>
-    get() = softwareSystems.filter { it.includedSoftwareSystem }
-
-val SoftwareSystem.includedSoftwareSystem
-    get() = this.location != Location.External
+    get() = if (softwareSystems.any { it.group != null })
+        softwareSystems.filter { it.group != null }
+    else
+        softwareSystems.filter { it.location != Location.External }
 
 val Container.hasComponents
     get() = this.components.isNotEmpty()

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
@@ -11,7 +11,7 @@ import nl.avisi.structurizr.site.generatr.*
 
 class C4PlantUmlExporterWithElementLinks(
     private val url: String
-): C4PlantUMLExporter() {
+) : C4PlantUMLExporter() {
     companion object {
         const val TEMP_URI = "https://will-be-changed-to-relative/"
 
@@ -48,7 +48,7 @@ class C4PlantUmlExporterWithElementLinks(
     }
 
     private fun needsLinkToSoftwareSystem(element: Element?, view: ModelView?) =
-        element is SoftwareSystem && element.includedSoftwareSystem && element != view?.softwareSystem
+        element is SoftwareSystem && view != null && view.model.includedSoftwareSystems.contains(element) && element != view.softwareSystem
 
     private fun getUrlToSoftwareSystem(element: Element?): String {
         val path = "/${element?.name?.normalize()}/context/".asUrlToDirectory(url)
@@ -56,7 +56,7 @@ class C4PlantUmlExporterWithElementLinks(
     }
 
     private fun needsLinkToContainerViews(element: Element?, view: ModelView?) =
-        element is SoftwareSystem && element.includedSoftwareSystem && element == view?.softwareSystem && element.hasContainers
+        element is SoftwareSystem && view != null && view.model.includedSoftwareSystems.contains(element) && element == view.softwareSystem && element.hasContainers
 
     private fun getUrlToContainerViews(element: Element?): String {
         val path = "/${element?.name?.normalize()}/container/".asUrlToDirectory(url)
@@ -88,5 +88,4 @@ class C4PlantUmlExporterWithElementLinks(
             .split(System.lineSeparator())
             .forEach { line -> writer?.writeLine(line) }
     }
-
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/C4PlantUmlExporterWithElementLinks.kt
@@ -1,5 +1,6 @@
 package nl.avisi.structurizr.site.generatr.site
 
+import com.structurizr.Workspace
 import com.structurizr.export.Diagram
 import com.structurizr.export.IndentingWriter
 import com.structurizr.export.plantuml.C4PlantUMLExporter
@@ -10,6 +11,7 @@ import com.structurizr.view.*
 import nl.avisi.structurizr.site.generatr.*
 
 class C4PlantUmlExporterWithElementLinks(
+    private val workspace: Workspace,
     private val url: String
 ) : C4PlantUMLExporter() {
     companion object {
@@ -48,7 +50,7 @@ class C4PlantUmlExporterWithElementLinks(
     }
 
     private fun needsLinkToSoftwareSystem(element: Element?, view: ModelView?) =
-        element is SoftwareSystem && view != null && view.model.includedSoftwareSystems.contains(element) && element != view.softwareSystem
+        element is SoftwareSystem && workspace.includedSoftwareSystems.contains(element) && element != view?.softwareSystem
 
     private fun getUrlToSoftwareSystem(element: Element?): String {
         val path = "/${element?.name?.normalize()}/context/".asUrlToDirectory(url)
@@ -56,7 +58,7 @@ class C4PlantUmlExporterWithElementLinks(
     }
 
     private fun needsLinkToContainerViews(element: Element?, view: ModelView?) =
-        element is SoftwareSystem && view != null && view.model.includedSoftwareSystems.contains(element) && element == view.softwareSystem && element.hasContainers
+        element is SoftwareSystem && workspace.includedSoftwareSystems.contains(element) && element == view?.softwareSystem && element.hasContainers
 
     private fun getUrlToContainerViews(element: Element?): String {
         val path = "/${element?.name?.normalize()}/container/".asUrlToDirectory(url)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
@@ -9,6 +9,7 @@ import com.structurizr.view.View
 import net.sourceforge.plantuml.FileFormat
 import net.sourceforge.plantuml.FileFormatOption
 import net.sourceforge.plantuml.SourceStringReader
+import nl.avisi.structurizr.site.generatr.includedSoftwareSystems
 import nl.avisi.structurizr.site.generatr.site.C4PlantUmlExporterWithElementLinks.Companion.export
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -83,7 +84,7 @@ private fun saveAsPng(diagram: Diagram, pngDir: File) {
 }
 
 private fun generatePlantUMLDiagramWithElementLinks(workspace: Workspace, view: View, url: String): Diagram {
-    val plantUMLExporter = C4PlantUmlExporterWithElementLinks(url)
+    val plantUMLExporter = C4PlantUmlExporterWithElementLinks(workspace, url)
 
     if (workspace.views.configuration.properties.containsKey("generatr.svglink.target")) {
         plantUMLExporter.addSkinParam(

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -131,7 +131,7 @@ private fun generateHtmlFiles(context: GeneratorContext, branchDir: File) {
                 add { writeHtmlFile(branchDir, WorkspaceDecisionPageViewModel(context, it)) }
             }
 
-        context.workspace.model.includedSoftwareSystems.forEach {
+        context.workspace.includedSoftwareSystems.forEach {
             add { writeHtmlFile(branchDir, SoftwareSystemHomePageViewModel(context, it)) }
             add { writeHtmlFile(branchDir, SoftwareSystemContextPageViewModel(context, it)) }
             add { writeHtmlFile(branchDir, SoftwareSystemContainerPageViewModel(context, it)) }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModel.kt
@@ -28,8 +28,7 @@ class MenuViewModel(generatorContext: GeneratorContext, private val pageViewMode
     private val groupSeparator = generatorContext.workspace.model.properties["structurizr.groupSeparator"] ?: "/"
 
     private val softwareSystemPaths = generatorContext.workspace.model.includedSoftwareSystems
-        .filter { it.group != null }
-        .map { it.group + groupSeparator + it.name }
+        .map { "${it.group ?: ""}$groupSeparator${it.name}" }
         .sortedBy { it.lowercase() }
 
     private fun createMenuItem(title: String, href: String, exact: Boolean = true) =

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModel.kt
@@ -25,7 +25,7 @@ class MenuViewModel(generatorContext: GeneratorContext, private val pageViewMode
             createMenuItem(it.name, SoftwareSystemPageViewModel.url(it, SoftwareSystemPageViewModel.Tab.HOME), false)
         }
 
-    private val groupSeparator = generatorContext.workspace.model.properties["structurizr.groupSeparator"]
+    private val groupSeparator = generatorContext.workspace.model.properties["structurizr.groupSeparator"] ?: "/"
 
     private val softwareSystemPaths = generatorContext.workspace.model.includedSoftwareSystems
         .filter { it.group != null }
@@ -39,8 +39,6 @@ class MenuViewModel(generatorContext: GeneratorContext, private val pageViewMode
         data class MutableMenuNode(val name: String, val children: MutableList<MutableMenuNode>) {
             fun toMenuNode(): MenuNodeViewModel = MenuNodeViewModel(name, children.map { it.toMenuNode() })
         }
-        if (groupSeparator == null)
-            throw IllegalStateException("Property structurizr.groupSeparator not defined for model") // This is also validated earlier by structurizr when parsing the model
 
         val rootNode = MutableMenuNode("", mutableListOf())
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModel.kt
@@ -1,6 +1,5 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
-import nl.avisi.structurizr.site.generatr.includedSoftwareSystems
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class MenuViewModel(generatorContext: GeneratorContext, private val pageViewModel: PageViewModel) {
@@ -19,7 +18,7 @@ class MenuViewModel(generatorContext: GeneratorContext, private val pageViewMode
             .forEach { yield(createMenuItem(it.contentTitle(), WorkspaceDocumentationSectionPageViewModel.url(it))) }
     }.toList()
 
-    val softwareSystemItems = generatorContext.workspace.model.includedSoftwareSystems
+    val softwareSystemItems = pageViewModel.includedSoftwareSystems
         .sortedBy { it.name.lowercase() }
         .map {
             createMenuItem(it.name, SoftwareSystemPageViewModel.url(it, SoftwareSystemPageViewModel.Tab.HOME), false)
@@ -27,7 +26,7 @@ class MenuViewModel(generatorContext: GeneratorContext, private val pageViewMode
 
     private val groupSeparator = generatorContext.workspace.model.properties["structurizr.groupSeparator"] ?: "/"
 
-    private val softwareSystemPaths = generatorContext.workspace.model.includedSoftwareSystems
+    private val softwareSystemPaths = pageViewModel.includedSoftwareSystems
         .map { "${it.group ?: ""}$groupSeparator${it.name}" }
         .sortedBy { it.lowercase() }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -1,5 +1,6 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
+import nl.avisi.structurizr.site.generatr.includedSoftwareSystems
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
@@ -19,6 +20,7 @@ abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
     val flexmarkConfig by lazy { buildFlexmarkConfig(generatorContext) }
     val includeAdmonition = flexmarkConfig.selectedExtensionMap.containsKey("Admonition")
     val includeKatex = flexmarkConfig.selectedExtensionMap.containsKey("GitLab")
+    val includedSoftwareSystems = generatorContext.workspace.model.includedSoftwareSystems
     val configuration = generatorContext.workspace.views.configuration.properties
     val includeTreeview = configuration.getOrDefault("generatr.site.nestGroups", "false").toBoolean()
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -20,7 +20,7 @@ abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
     val flexmarkConfig by lazy { buildFlexmarkConfig(generatorContext) }
     val includeAdmonition = flexmarkConfig.selectedExtensionMap.containsKey("Admonition")
     val includeKatex = flexmarkConfig.selectedExtensionMap.containsKey("GitLab")
-    val includedSoftwareSystems = generatorContext.workspace.model.includedSoftwareSystems
+    val includedSoftwareSystems = generatorContext.workspace.includedSoftwareSystems
     val configuration = generatorContext.workspace.views.configuration.properties
     val includeTreeview = configuration.getOrDefault("generatr.site.nestGroups", "false").toBoolean()
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModel.kt
@@ -1,6 +1,5 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
-import nl.avisi.structurizr.site.generatr.includedSoftwareSystem
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 import nl.avisi.structurizr.site.generatr.site.model.indexing.home
 import nl.avisi.structurizr.site.generatr.site.model.indexing.softwareSystemComponents
@@ -25,8 +24,7 @@ class SearchViewModel(generatorContext: GeneratorContext) : PageViewModel(genera
         addAll(workspaceDecisions(generatorContext.workspace.documentation, this@SearchViewModel))
         addAll(workspaceSections(generatorContext.workspace.documentation, this@SearchViewModel))
         addAll(
-            generatorContext.workspace.model.softwareSystems
-                .filter { it.includedSoftwareSystem }
+            includedSoftwareSystems
                 .flatMap {
                     buildList {
                         add(softwareSystemHome(it, this@SearchViewModel))

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemTableUtilities.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemTableUtilities.kt
@@ -6,11 +6,11 @@ import com.structurizr.model.SoftwareSystem
 fun TableViewModel.TableViewInitializerContext.softwareSystemCell(
     pageViewModel: PageViewModel,
     system: SoftwareSystem
-) = if (system.location == Location.External)
-    headerCell("${system.name} (External)", greyText = true)
-else
+) = if (pageViewModel.includedSoftwareSystems.contains(system))
     headerCellWithLink(
         pageViewModel,
         system.name,
         SoftwareSystemPageViewModel.url(system, SoftwareSystemPageViewModel.Tab.HOME)
     )
+else
+    headerCell("${system.name} (External)", greyText = true)

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModelTest.kt
@@ -147,10 +147,11 @@ class MenuViewModelTest : ViewModelTest() {
     }
 
     @Test
-    fun `do not show menu entries for software systems with an external location (outside of any group when using groups)`() {
+    fun `do not show menu entries for software systems with an external location (declared external by tag)`() {
         val generatorContext = generatorContext(branches = listOf("main", "branch-2"), currentBranch = "main")
+        generatorContext.workspace.views.configuration.addProperty("generatr.site.externalTag", "External System")
         generatorContext.workspace.model.addSoftwareSystem("System 1").apply { group = "Group 1" }
-        generatorContext.workspace.model.addSoftwareSystem("External system")
+        generatorContext.workspace.model.addSoftwareSystem("External system").apply { addTags("External System") }
 
         MenuViewModel(generatorContext, createPageViewModel(generatorContext, url = HomePageViewModel.url()))
             .let {

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModelTest.kt
@@ -181,6 +181,22 @@ class MenuViewModelTest : ViewModelTest() {
             }
     }
 
+    @Test
+    fun `do not show menu items of software systems outside of groups when groups are used`() {
+        val generatorContext = generatorContext(branches = listOf("main", "branch-2"), currentBranch = "main")
+        generatorContext.workspace.views.configuration.addProperty("generatr.site.nestGroups", "true")
+        generatorContext.workspace.model.addSoftwareSystem("System 1").group = "Group 1"
+        generatorContext.workspace.model.addSoftwareSystem("External system")
+
+        MenuViewModel(generatorContext, createPageViewModel(generatorContext, url = HomePageViewModel.url()))
+            .let {
+                assertThat(it.softwareSystemNodes().children).hasSize(1)
+                assertThat(it.softwareSystemNodes().children[0].name).isEqualTo("Group 1")
+                assertThat(it.softwareSystemNodes().children[0].children).hasSize(1)
+                assertThat(it.softwareSystemNodes().children[0].children[0].name).isEqualTo("System 1")
+            }
+    }
+
     private fun createPageViewModel(generatorContext: GeneratorContext, url: String = "/master/page"): PageViewModel {
         return object : PageViewModel(generatorContext) {
             override val url = url

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModelTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import com.structurizr.documentation.Format
 import com.structurizr.documentation.Section
+import com.structurizr.model.Location
 import org.junit.jupiter.api.Test
 
 class SearchViewModelTest : ViewModelTest() {
@@ -59,6 +60,31 @@ class SearchViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.documents.map { it.type })
             .containsExactly("Context views")
+    }
+
+    @Test
+    fun `indexes no external software system (outside enterprise boundary)`() {
+        val generatorContext = generatorContext()
+        generatorContext.workspace.apply {
+            model.addSoftwareSystem("Software system").apply { location = Location.External }
+        }
+        val viewModel = SearchViewModel(generatorContext)
+
+        assertThat(viewModel.documents.map { it.type })
+            .isEmpty()
+    }
+
+    @Test
+    fun `indexes no external software system (declared external by tag)`() {
+        val generatorContext = generatorContext()
+        generatorContext.workspace.apply {
+            views.configuration.addProperty("generatr.site.externalTag", "External System")
+            model.addSoftwareSystem("Software system").apply { addTags("External System") }
+        }
+        val viewModel = SearchViewModel(generatorContext)
+
+        assertThat(viewModel.documents.map { it.type })
+            .isEmpty()
     }
 
     @Test

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
@@ -81,6 +81,7 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
         softwareSystem1.uses(backend2, "Uses from system 1 to container 2", "REST")
 
         val viewModel = SoftwareSystemDependenciesPageViewModel(generatorContext, softwareSystem1)
+
         // Inbound Table
         assertThat(viewModel.dependenciesInboundTable.bodyRows.extractTitle())
             .containsExactly("Software system 2")
@@ -95,8 +96,8 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
             .addSoftwareSystem(Location.External, "External system", "")
         externalSystem.uses(softwareSystem1, "Uses", "REST")
         softwareSystem1.uses(externalSystem, "Uses", "REST")
-
         val viewModel = SoftwareSystemDependenciesPageViewModel(generatorContext, softwareSystem1)
+
         assertThat(viewModel.dependenciesInboundTable.bodyRows[0].columns[0])
             .isEqualTo(TableViewModel.TextCellViewModel("External system (External)", isHeader = true, greyText = true))
         assertThat(viewModel.dependenciesOutboundTable.bodyRows[0].columns[0])
@@ -104,13 +105,14 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
     }
 
     @Test
-    fun `dependencies from and to external systems (outside of any group when using groups)`() {
-        softwareSystem1.group = "Group 1"
-        val externalSystem = generatorContext.workspace.model.addSoftwareSystem("External system")
+    fun `dependencies from and to external systems (declared external by tag)`() {
+        generatorContext.workspace.views.configuration.addProperty("generatr.site.externalTag", "External System")
+        val externalSystem = generatorContext.workspace.model.addSoftwareSystem("External system").apply { addTags("External System") }
         externalSystem.uses(softwareSystem1, "Uses", "REST")
         softwareSystem1.uses(externalSystem, "Uses", "REST")
 
         val viewModel = SoftwareSystemDependenciesPageViewModel(generatorContext, softwareSystem1)
+
         assertThat(viewModel.dependenciesInboundTable.bodyRows[0].columns[0])
             .isEqualTo(TableViewModel.TextCellViewModel("External system (External)", isHeader = true, greyText = true))
         assertThat(viewModel.dependenciesOutboundTable.bodyRows[0].columns[0])
@@ -123,8 +125,8 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
         system.uses(softwareSystem1, "Uses", "REST")
         softwareSystem1.uses(softwareSystem2, "Uses REST", "REST")
         softwareSystem2.uses(softwareSystem1, "Uses SOAP", "SOAP")
-
         val viewModel = SoftwareSystemDependenciesPageViewModel(generatorContext, softwareSystem1)
+
         // Inbound Table
         assertThat(viewModel.dependenciesInboundTable.bodyRows.extractTitle())
             .containsExactly("Software system 2", "Software system 3")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
@@ -90,9 +90,23 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
     }
 
     @Test
-    fun `dependencies from and to external systems`() {
+    fun `dependencies from and to external systems (outside enterprise boundary)`() {
         val externalSystem = generatorContext.workspace.model
             .addSoftwareSystem(Location.External, "External system", "")
+        externalSystem.uses(softwareSystem1, "Uses", "REST")
+        softwareSystem1.uses(externalSystem, "Uses", "REST")
+
+        val viewModel = SoftwareSystemDependenciesPageViewModel(generatorContext, softwareSystem1)
+        assertThat(viewModel.dependenciesInboundTable.bodyRows[0].columns[0])
+            .isEqualTo(TableViewModel.TextCellViewModel("External system (External)", isHeader = true, greyText = true))
+        assertThat(viewModel.dependenciesOutboundTable.bodyRows[0].columns[0])
+            .isEqualTo(TableViewModel.TextCellViewModel("External system (External)", isHeader = true, greyText = true))
+    }
+
+    @Test
+    fun `dependencies from and to external systems (outside of any group when using groups)`() {
+        softwareSystem1.group = "Group 1"
+        val externalSystem = generatorContext.workspace.model.addSoftwareSystem("External system")
         externalSystem.uses(softwareSystem1, "Uses", "REST")
         softwareSystem1.uses(externalSystem, "Uses", "REST")
 

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemsPageViewModelTest.kt
@@ -69,12 +69,23 @@ class SoftwareSystemsPageViewModelTest : ViewModelTest() {
     }
 
     @Test
-    fun `external systems have grey text`() {
+    fun `external systems have grey text (outside enterprise boundary)`() {
         val generatorContext = generatorContext()
         generatorContext.workspace.model.addSoftwareSystem(Location.External, "system 1", "System 1 description")
         val viewModel = SoftwareSystemsPageViewModel(generatorContext)
 
         assertThat(viewModel.softwareSystemsTable.bodyRows[0].columns[0])
             .isEqualTo(TableViewModel.TextCellViewModel("system 1 (External)", isHeader = true, greyText = true))
+    }
+
+    @Test
+    fun `external systems have grey text (outside of any group when using groups)`() {
+        val generatorContext = generatorContext()
+        generatorContext.workspace.model.addSoftwareSystem("system 1", "System 1 description").apply { group = "Group 1" }
+        generatorContext.workspace.model.addSoftwareSystem("system 2", "System 2 description")
+        val viewModel = SoftwareSystemsPageViewModel(generatorContext)
+
+        assertThat(viewModel.softwareSystemsTable.bodyRows[1].columns[0])
+            .isEqualTo(TableViewModel.TextCellViewModel("system 2 (External)", isHeader = true, greyText = true))
     }
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemsPageViewModelTest.kt
@@ -79,10 +79,12 @@ class SoftwareSystemsPageViewModelTest : ViewModelTest() {
     }
 
     @Test
-    fun `external systems have grey text (outside of any group when using groups)`() {
+    fun `external systems have grey text (declared external by tag)`() {
         val generatorContext = generatorContext()
-        generatorContext.workspace.model.addSoftwareSystem("system 1", "System 1 description").apply { group = "Group 1" }
-        generatorContext.workspace.model.addSoftwareSystem("system 2", "System 2 description")
+        generatorContext.workspace.views.configuration.addProperty("generatr.site.externalTag", "External System")
+        generatorContext.workspace.model.addSoftwareSystem("system 1", "System 1 description")
+        generatorContext.workspace.model.addSoftwareSystem("system 2", "System 2 description").apply { addTags("External System") }
+
         val viewModel = SoftwareSystemsPageViewModel(generatorContext)
 
         assertThat(viewModel.softwareSystemsTable.bodyRows[1].columns[0])


### PR DESCRIPTION
There no concept anymore of external/internal locations when not using the now deprecated enterprise boundary. ~Do we still want to exclude software systems somehow like we do now with systems outside the enterprise?~

