### PR TITLE
Allow customization of the diagram exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ Generatr container. So
 is needed to expose the container's port 8080 to the host (web browser). In the example above, the
 `-p 8080:8080` argument tells Docker to bind the local machine / host's port 8080 to the container's port 8080.
 
+### Customize the diagram exporter
+
+To customize the exported diagrams the paramater `--exporter-type` or `-exp` can be used.
+
+Currently supported exporters:
+* `c4` uses the `C4PlantUMLExporter` (default)
+* `structurizr` uses the `StructurizrPlantUMLExporter`
+
 ## Customizing the generated website
 
 The site generator use the

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -62,7 +62,10 @@ class GenerateSiteCommand : Subcommand(
         ArgType.String, "exclude-branches", "ex",
         "Comma-separated list of branches to exclude from the generated site"
     ).default("")
-
+    private val exporterType by option(
+            ArgType.String, "exporter-type", "exp",
+            "Set diagram exporter type. (C4 and Structurizr are supported)."
+    ).default(value = "C4")
     override fun execute() {
         val siteDir = File(outputDir).apply { mkdirs() }
         val gitUrl = gitUrl
@@ -114,28 +117,30 @@ class GenerateSiteCommand : Subcommand(
             clonedRepository.checkoutBranch(branch)
 
             val workspace = createStructurizrWorkspace(workspaceFileInRepo)
-            generateDiagrams(workspace, File(siteDir, branch))
+            generateDiagrams(workspace, File(siteDir, branch), exporterType)
             generateSite(
                 version,
                 workspace,
                 assetsDir?.let { File(cloneDir, it) },
                 siteDir,
                 branchesToGenerate,
-                branch
+                branch,
+                exporterType
             )
         }
     }
 
     private fun generateSiteForModel(siteDir: File) {
         val workspace = createStructurizrWorkspace(File(workspaceFile))
-        generateDiagrams(workspace, File(siteDir, defaultBranch))
+        generateDiagrams(workspace, File(siteDir, defaultBranch), exporterType)
         generateSite(
             version,
             workspace,
             assetsDir?.let { File(it) },
             siteDir,
             listOf(defaultBranch),
-            defaultBranch
+            defaultBranch,
+            exporterType
         )
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -44,6 +44,10 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
     private val port by option(
         ArgType.Int, "port", "p", "Port the site is served on"
     ).default(8080)
+    private val exporterType by option(
+            ArgType.String, "exporter-type", "exp",
+            "Set diagram exporter type. (C4 and Structurizr are supported)."
+    ).default(value = "C4")
 
     private val eventSockets = mutableListOf<EventSocket>()
     private val eventSocketsLock = Any()
@@ -80,7 +84,7 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
                 println("Copying assets...")
                 copySiteWideAssets(File(siteDir))
                 println("Generating diagrams...")
-                generateDiagrams(workspace, exportDir)
+                generateDiagrams(workspace, exportDir, exporterType)
                 println("Generating site...")
                 generateSite(
                     "0.0.0",
@@ -89,6 +93,7 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
                     File(siteDir),
                     listOf(branch),
                     branch,
+                    exporterType,
                     serving = true
                 )
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
@@ -2,26 +2,27 @@ package nl.avisi.structurizr.site.generatr.site
 
 import com.structurizr.Workspace
 import com.structurizr.export.Diagram
-import com.structurizr.export.plantuml.C4PlantUMLExporter
 import com.structurizr.export.plantuml.PlantUMLDiagram
 import com.structurizr.view.ModelView
 import com.structurizr.view.View
 import net.sourceforge.plantuml.FileFormat
 import net.sourceforge.plantuml.FileFormatOption
 import net.sourceforge.plantuml.SourceStringReader
-import nl.avisi.structurizr.site.generatr.includedSoftwareSystems
 import nl.avisi.structurizr.site.generatr.site.C4PlantUmlExporterWithElementLinks.Companion.export
+import nl.avisi.structurizr.site.generatr.site.factory.PlantUMLExporterFactory
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
 
-fun generateDiagrams(workspace: Workspace, exportDir: File) {
+val exporterFactory = PlantUMLExporterFactory()
+
+fun generateDiagrams(workspace: Workspace, exportDir: File, exporterType: String) {
     val pumlDir = pumlDir(exportDir)
     val svgDir = svgDir(exportDir)
     val pngDir = pngDir(exportDir)
 
-    val plantUMLDiagrams = generatePlantUMLDiagrams(workspace)
+    val plantUMLDiagrams = generatePlantUMLDiagrams(workspace, exporterType)
 
     plantUMLDiagrams.parallelStream()
         .forEach { diagram ->
@@ -41,9 +42,10 @@ fun generateDiagramWithElementLinks(
     workspace: Workspace,
     view: View,
     url: String,
+    exporterType: String,
     diagramCache: ConcurrentHashMap<String, String>
 ): String {
-    val diagram = generatePlantUMLDiagramWithElementLinks(workspace, view, url)
+    val diagram = generatePlantUMLDiagramWithElementLinks(workspace, view, url, exporterType)
 
     val name = "${diagram.key}-${view.key}"
     return diagramCache.getOrPut(name) {
@@ -55,8 +57,8 @@ fun generateDiagramWithElementLinks(
     }
 }
 
-private fun generatePlantUMLDiagrams(workspace: Workspace): Collection<Diagram> {
-    val plantUMLExporter = C4PlantUMLExporter()
+private fun generatePlantUMLDiagrams(workspace: Workspace, exporterType: String): Collection<Diagram> {
+    val plantUMLExporter = exporterFactory.makeExporter(exporterType)
 
     return plantUMLExporter.export(workspace)
 }
@@ -83,8 +85,8 @@ private fun saveAsPng(diagram: Diagram, pngDir: File) {
     }
 }
 
-private fun generatePlantUMLDiagramWithElementLinks(workspace: Workspace, view: View, url: String): Diagram {
-    val plantUMLExporter = C4PlantUmlExporterWithElementLinks(workspace, url)
+private fun generatePlantUMLDiagramWithElementLinks(workspace: Workspace, view: View, url: String, exporterType: String): Diagram {
+    val plantUMLExporter = exporterFactory.makeExporterWithLinks(exporterType, workspace, url)
 
     if (workspace.views.configuration.properties.containsKey("generatr.svglink.target")) {
         plantUMLExporter.addSkinParam(
@@ -95,6 +97,7 @@ private fun generatePlantUMLDiagramWithElementLinks(workspace: Workspace, view: 
 
     return plantUMLExporter.export(view)
 }
+
 
 private fun pumlDir(exportDir: File) = File(exportDir, "puml").apply { mkdirs() }
 private fun svgDir(exportDir: File) = File(exportDir, "svg").apply { mkdirs() }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -60,12 +60,13 @@ fun generateSite(
     exportDir: File,
     branches: List<String>,
     currentBranch: String,
+    exporterType: String,
     serving: Boolean = false
 ) {
     val generatorContext = GeneratorContext(version, workspace, branches, currentBranch, serving) { key, url ->
         val diagramCache = ConcurrentHashMap<String, String>()
         workspace.views.views.singleOrNull { view -> view.key == key }
-            ?.let { generateDiagramWithElementLinks(workspace, it, url, diagramCache) }
+            ?.let { generateDiagramWithElementLinks(workspace, it, url, exporterType, diagramCache) }
     }
 
     val branchDir = File(exportDir, currentBranch)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/StructurizrPlantUmlExporterWithElementLinks.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/StructurizrPlantUmlExporterWithElementLinks.kt
@@ -4,17 +4,17 @@ import com.structurizr.Workspace
 import com.structurizr.export.Diagram
 import com.structurizr.export.IndentingWriter
 import com.structurizr.export.plantuml.AbstractPlantUMLExporter
-import com.structurizr.export.plantuml.C4PlantUMLExporter
+import com.structurizr.export.plantuml.StructurizrPlantUMLExporter
 import com.structurizr.model.Container
 import com.structurizr.model.Element
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.*
 import nl.avisi.structurizr.site.generatr.*
 
-class C4PlantUmlExporterWithElementLinks(
+class StructurizrPlantUmlExporterWithElementLinks(
     private val workspace: Workspace,
     private val url: String
-) : C4PlantUMLExporter() {
+) : StructurizrPlantUMLExporter() {
     companion object {
         const val TEMP_URI = "https://will-be-changed-to-relative/"
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/factory/PlantUMLExporterFactory.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/factory/PlantUMLExporterFactory.kt
@@ -1,0 +1,27 @@
+package nl.avisi.structurizr.site.generatr.site.factory
+
+import com.structurizr.Workspace
+import com.structurizr.export.plantuml.AbstractPlantUMLExporter
+import com.structurizr.export.plantuml.C4PlantUMLExporter
+import com.structurizr.export.plantuml.StructurizrPlantUMLExporter
+import nl.avisi.structurizr.site.generatr.site.C4PlantUmlExporterWithElementLinks
+import nl.avisi.structurizr.site.generatr.site.StructurizrPlantUmlExporterWithElementLinks
+import java.util.*
+
+class PlantUMLExporterFactory {
+    fun makeExporter(type: String): AbstractPlantUMLExporter {
+        return when(type.lowercase(Locale.getDefault())) {
+            "c4" -> C4PlantUMLExporter()
+            "structurizr" -> StructurizrPlantUMLExporter()
+            else -> throw Exception("unknown diagram exporter type")
+        }
+    }
+
+    fun makeExporterWithLinks(type: String, workspace: Workspace, url: String): AbstractPlantUMLExporter {
+        return when(type.lowercase(Locale.getDefault())) {
+            "c4" -> C4PlantUmlExporterWithElementLinks(workspace,url)
+            "structurizr" -> StructurizrPlantUmlExporterWithElementLinks(workspace, url)
+            else -> throw Exception("unknown diagram exporter type")
+        }
+    }
+}


### PR DESCRIPTION
Currently the diagrams are exported with the `C4PlantUMLExporter`.

This PR adds a new command line paramter `exporter-type` to select the diagram exporter.

Further the `Structurizr` exporter is added.