### PR TITLE
Fix the hidding tabs

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionsPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionsPage.kt
@@ -14,7 +14,7 @@ fun HTML.softwareSystemSectionsPage(viewModel: SoftwareSystemSectionsPageViewMod
     } else if (viewModel.visible)
         softwareSystemPage(viewModel) {
             div(classes = "tabs") {
-                ul(classes = "m-0") {
+                ul(classes = "m-0 is-flex-wrap-wrap is-flex-shrink-1 is-flex-grow-0") {
                     viewModel.sectionTabs
                         .forEach {
                             li(classes = if (it.link.active) "is-active" else null) {


### PR DESCRIPTION
This is fixing an issue with inaccessible tabs when you have more than just a couple of containers. Example of issue:
<img width="1425" alt="Screenshot 2024-01-02 at 11 12 06" src="https://github.com/avisi-cloud/structurizr-site-generatr/assets/759579/c6e6ca92-e078-4d9d-b4fa-8cfaf0f5edef">


After changes:
<img width="1136" alt="Screenshot 2024-01-02 at 11 11 44" src="https://github.com/avisi-cloud/structurizr-site-generatr/assets/759579/d538c83c-b46d-4d52-bb6b-3cfdb87e41e4">


It's not pretty, but it does its job ;). I doubt more people have this problem, but I'm open if we would like to change it.