### PR TITLE
Add function to export the DSL as a JSON file.

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/GenerateSiteCommand.kt
@@ -3,10 +3,7 @@
 package nl.avisi.structurizr.site.generatr
 
 import kotlinx.cli.*
-import nl.avisi.structurizr.site.generatr.site.copySiteWideAssets
-import nl.avisi.structurizr.site.generatr.site.generateDiagrams
-import nl.avisi.structurizr.site.generatr.site.generateRedirectingIndexPage
-import nl.avisi.structurizr.site.generatr.site.generateSite
+import nl.avisi.structurizr.site.generatr.site.*
 import java.io.File
 
 class GenerateSiteCommand : Subcommand(
@@ -114,6 +111,7 @@ class GenerateSiteCommand : Subcommand(
             clonedRepository.checkoutBranch(branch)
 
             val workspace = createStructurizrWorkspace(workspaceFileInRepo)
+            writeStructurizrJson(workspace, File(siteDir, branch))
             generateDiagrams(workspace, File(siteDir, branch))
             generateSite(
                 version,
@@ -128,6 +126,7 @@ class GenerateSiteCommand : Subcommand(
 
     private fun generateSiteForModel(siteDir: File) {
         val workspace = createStructurizrWorkspace(File(workspaceFile))
+        writeStructurizrJson(workspace, File(siteDir, defaultBranch))
         generateDiagrams(workspace, File(siteDir, defaultBranch))
         generateSite(
             version,

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -4,10 +4,7 @@ package nl.avisi.structurizr.site.generatr
 
 import com.sun.nio.file.SensitivityWatchEventModifier
 import kotlinx.cli.*
-import nl.avisi.structurizr.site.generatr.site.copySiteWideAssets
-import nl.avisi.structurizr.site.generatr.site.generateDiagrams
-import nl.avisi.structurizr.site.generatr.site.generateRedirectingIndexPage
-import nl.avisi.structurizr.site.generatr.site.generateSite
+import nl.avisi.structurizr.site.generatr.site.*
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ContextHandler
 import org.eclipse.jetty.server.handler.ContextHandlerCollection
@@ -79,6 +76,8 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
                 generateRedirectingIndexPage(File(siteDir), branch)
                 println("Copying assets...")
                 copySiteWideAssets(File(siteDir))
+                println("Generating Json Export...")
+                writeStructurizrJson(workspace, exportDir)
                 println("Generating diagrams...")
                 generateDiagrams(workspace, exportDir)
                 println("Generating site...")

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -76,7 +76,7 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
                 generateRedirectingIndexPage(File(siteDir), branch)
                 println("Copying assets...")
                 copySiteWideAssets(File(siteDir))
-                println("Generating Json Export...")
+                println("Writing workspace.json...")
                 writeStructurizrJson(workspace, exportDir)
                 println("Generating diagrams...")
                 generateDiagrams(workspace, exportDir)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -54,10 +54,9 @@ fun generateRedirectingIndexPage(exportDir: File, defaultBranch: String) {
     )
 }
 
-fun writeStructurizrJson(workspace: Workspace, exportDir: File){
-    val jsonFile = File(exportDir, "workspace.json")
-    val x = WorkspaceUtils.toJson(workspace,true)
-    jsonFile.writeText(x)
+fun writeStructurizrJson(workspace: Workspace, exportDir: File) {
+    val json = WorkspaceUtils.toJson(workspace, true)
+    File(exportDir, "workspace.json").writeText(json)
 }
 
 fun generateSite(

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -1,6 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site
 
 import com.structurizr.Workspace
+import com.structurizr.util.WorkspaceUtils
 import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
 import nl.avisi.structurizr.site.generatr.includedSoftwareSystems
@@ -51,6 +52,12 @@ fun generateRedirectingIndexPage(exportDir: File, defaultBranch: String) {
             }
         }
     )
+}
+
+fun writeStructurizrJson(workspace: Workspace, exportDir: File){
+    val jsonFile = File(exportDir, "workspace.json")
+    val x = WorkspaceUtils.toJson(workspace,true)
+    jsonFile.writeText(x)
 }
 
 fun generateSite(


### PR DESCRIPTION
Added an export of the DSL file as JSON (workspace.json) in the branch directory.

While this does not add anything to the application I have a very specific need to be able to get the JSON that defines the DSL so that I can read it in from another app each time the site is generated.