### PR TITLE
Align presentation of diagrams and images

### DIFF
--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -207,6 +207,8 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
                 email
             }
             autoLayout
+            title "System Context of Internet Banking System"
+            description "Describes the overall context"
         }
 
         container internetBankingSystem "Containers" {
@@ -235,13 +237,13 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
 
         image database {
             image internet-banking-system/database-erd-example.jpg
-            title "Internet Banking System - Database - Entity Relationship Diagram"
+            title "Entity Relationship Diagram"
             description "Image View to show the ERD diagram for the database container"
         }
 
         image accountsSummaryController {
             image internet-banking-system/uml-class-diagram.png
-            title "Internet Banking System - API Application - AccountsSummaryController Zoom-In"
+            title "AccountsSummaryController Zoom-In"
             description "This is a sample imageView for code of a component"
         }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -16,6 +16,7 @@ fun copySiteWideAssets(exportDir: File) {
     copySiteWideAsset(exportDir, "/css/style.css")
     copySiteWideAsset(exportDir, "/js/header.js")
     copySiteWideAsset(exportDir, "/js/svg-modal.js")
+    copySiteWideAsset(exportDir, "/js/modal.js")
     copySiteWideAsset(exportDir, "/js/search.js")
     copySiteWideAsset(exportDir, "/js/auto-reload.js")
     copySiteWideAsset(exportDir, "/css/admonition.css")

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
@@ -5,6 +5,7 @@ import com.structurizr.view.View
 data class DiagramViewModel(
     val key: String,
     val name: String,
+    val description: String?,
     val svg: String?,
     val diagramWidthInPixels: Int?,
     val svgLocation: ImageViewModel,
@@ -13,18 +14,20 @@ data class DiagramViewModel(
 ) {
     companion object {
         fun forView(pageViewModel: PageViewModel, view: View, svgFactory: (key: String, url: String) -> String?) =
-            forView(pageViewModel, view.key, view.name, svgFactory)
+            forView(pageViewModel, view.key, view.name, view.description.ifBlank { null }, svgFactory)
 
         fun forView(
             pageViewModel: PageViewModel,
             key: String,
             name: String,
+            description: String?,
             svgFactory: (key: String, url: String) -> String?
         ): DiagramViewModel {
             val svg = svgFactory(key, pageViewModel.url)
             return DiagramViewModel(
                 key,
                 name,
+                description,
                 svg,
                 extractDiagramWidthInPixels(svg),
                 ImageViewModel(pageViewModel, "/svg/$key.svg"),

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewViewModel.kt
@@ -6,7 +6,8 @@ import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ImageView
 
 data class ImageViewViewModel(val imageView: ImageView) {
-    val name: String get() = generateName()
+    val key: String = imageView.key
+    val name: String = generateName()
     val title: String = imageView.title
     val description: String? = imageView.description
     val content: String = imageView.content

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewViewModel.kt
@@ -1,0 +1,28 @@
+package nl.avisi.structurizr.site.generatr.site.model
+
+import com.structurizr.model.Component
+import com.structurizr.model.Container
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ImageView
+
+data class ImageViewViewModel(val imageView: ImageView) {
+    val name: String get() = generateName()
+    val title: String = imageView.title
+    val description: String? = imageView.description
+    val content: String = imageView.content
+
+    private fun generateName(): String {
+        val elementName = generateSequence(imageView.element) {
+            it.parent
+        }.map { it.name }.toList().reversed().joinToString(" - ")
+
+        val elementType = when (imageView.element) {
+            is SoftwareSystem -> "Containers"
+            is Container -> "Components"
+            is Component -> "Code"
+            else -> throw IllegalStateException("Not supported element")
+        }
+
+        return "$elementName - $elementType"
+    }
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemCodePageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemCodePageViewModel.kt
@@ -8,5 +8,6 @@ class SoftwareSystemCodePageViewModel(generatorContext: GeneratorContext, softwa
     val images = generatorContext.workspace.views.imageViews
         .filter { it.elementId in softwareSystem.containers.flatMap { c -> c.components.map { com -> com.id } } }
         .sortedBy { it.key }
+        .map { ImageViewViewModel(it) }
     val visible = images.isNotEmpty()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModel.kt
@@ -13,5 +13,6 @@ class SoftwareSystemComponentPageViewModel(generatorContext: GeneratorContext, s
     val images = generatorContext.workspace.views.imageViews
         .filter { it.elementId in softwareSystem.containers.map { c -> c.id } }
         .sortedBy { it.key }
+        .map { ImageViewViewModel(it) }
     val visible = generatorContext.workspace.views.hasComponentViews(generatorContext.workspace, softwareSystem) || images.isNotEmpty()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModel.kt
@@ -13,5 +13,6 @@ class SoftwareSystemContainerPageViewModel(generatorContext: GeneratorContext, s
     val images = generatorContext.workspace.views.imageViews
         .filter { it.elementId == softwareSystem.id }
         .sortedBy { it.key }
+        .map { ImageViewViewModel(it) }
     val visible = generatorContext.workspace.views.hasContainerViews(generatorContext.workspace, softwareSystem) || images.isNotEmpty()
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ToHtml.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ToHtml.kt
@@ -160,7 +160,7 @@ fun Element.transformEmbeddedDiagramElements(
         val key = it.attr("src").substring(embedPrefix.length)
         val name = it.attr("alt").ifBlank { key }
         val html = createHTML().div {
-            diagram(DiagramViewModel.forView(pageViewModel, key, name, svgFactory))
+            diagram(DiagramViewModel.forView(pageViewModel, key, name, null, svgFactory))
         }
 
         it.parent()?.append(html)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
@@ -14,7 +14,7 @@ fun FlowContent.diagram(viewModel: DiagramViewModel) {
             rawHtml(viewModel.svg)
             figcaption {
                 a {
-                    onClick = "openModal('$dialogId', '$svgId')"
+                    onClick = "openSvgModal('$dialogId', '$svgId')"
                     +viewModel.name
                     if (!viewModel.description.isNullOrBlank()) {
                         br
@@ -23,44 +23,23 @@ fun FlowContent.diagram(viewModel: DiagramViewModel) {
                 }
             }
         }
-        svgModal(dialogId, svgId, viewModel)
+        modal(dialogId) {
+            // TODO: no links in this SVG
+            rawHtml(viewModel.svg, svgId, "modal-box-content")
+            div(classes = "has-text-centered") {
+                +" ["
+                a(href = viewModel.svgLocation.relativeHref, target = "_blank") { +"svg" }
+                +"|"
+                a(href = viewModel.pngLocation.relativeHref, target = "_blank") { +"png" }
+                +"|"
+                a(href = viewModel.pumlLocation.relativeHref, target = "_blank") { +"puml" }
+                +"]"
+            }
+        }
     } else
         div(classes = "notification is-danger") {
             +"No view with key"
             span(classes = "has-text-weight-bold") { +" ${viewModel.key} " }
             +"found!"
         }
-}
-
-private fun FlowContent.svgModal(
-    dialogId: String,
-    svgId: String,
-    viewModel: DiagramViewModel
-) {
-    div(classes = "modal") {
-        id = dialogId
-
-        div(classes = "modal-background") {
-            onClick = "closeModal('$dialogId')"
-        }
-        div(classes = "modal-content") {
-            div(classes = "box") {
-                // TODO: no links in this SVG
-                rawHtml(viewModel.svg!!, svgId, "modal-box-content")
-                div(classes = "has-text-centered") {
-                    +" ["
-                    a(href = viewModel.svgLocation.relativeHref, target = "_blank") { +"svg" }
-                    +"|"
-                    a(href = viewModel.pngLocation.relativeHref, target = "_blank") { +"png" }
-                    +"|"
-                    a(href = viewModel.pumlLocation.relativeHref, target = "_blank") { +"puml" }
-                    +"]"
-                }
-            }
-        }
-        button(classes = "modal-close is-large") {
-            attributes["aria-label"] = "close"
-            onClick = "closeModal('$dialogId')"
-        }
-    }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
@@ -41,6 +41,7 @@ private fun FlowContent.svgModal(
         }
         div(classes = "modal-content") {
             div(classes = "box") {
+                // TODO: no links in this SVG
                 rawHtml(viewModel.svg!!, svgId, "modal-box-content")
                 div(classes = "has-text-centered") {
                     +" ["

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
@@ -16,6 +16,10 @@ fun FlowContent.diagram(viewModel: DiagramViewModel) {
                 a {
                     onClick = "openModal('$dialogId', '$svgId')"
                     +viewModel.name
+                    if (!viewModel.description.isNullOrBlank()) {
+                        br
+                        +viewModel.description
+                    }
                 }
             }
         }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Image.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Image.kt
@@ -1,26 +1,33 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
-import kotlinx.html.FlowContent
-import kotlinx.html.br
-import kotlinx.html.figcaption
-import kotlinx.html.figure
-import kotlinx.html.img
-import kotlinx.html.p
-import kotlinx.html.style
+import kotlinx.html.*
 import nl.avisi.structurizr.site.generatr.site.model.ImageViewViewModel
 
 fun FlowContent.image(viewModel: ImageViewViewModel) {
+    val dialogId = "${viewModel.key}-modal"
+
     figure {
         style = "width: fit-content;"
 
         p(classes = "has-text-weight-bold") { +viewModel.title }
         img { src = viewModel.content }
         figcaption {
-            +viewModel.name
-            if (!viewModel.description.isNullOrBlank()) {
-                br
-                +viewModel.description
+            a {
+                onClick = "openModal('$dialogId')"
+                +viewModel.name
+                if (!viewModel.description.isNullOrBlank()) {
+                    br
+                    +viewModel.description
+                }
             }
+        }
+    }
+    modal(dialogId) {
+        img(classes = "modal-box-content modal-image") { src = viewModel.content }
+        div(classes = "has-text-centered") {
+            +" ["
+            a(href = viewModel.content, target = "_blank") { +"raw" }
+            +"]"
         }
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Image.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Image.kt
@@ -1,20 +1,26 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
-import com.structurizr.view.ImageView
 import kotlinx.html.FlowContent
+import kotlinx.html.br
 import kotlinx.html.figcaption
 import kotlinx.html.figure
 import kotlinx.html.img
 import kotlinx.html.p
+import kotlinx.html.style
+import nl.avisi.structurizr.site.generatr.site.model.ImageViewViewModel
 
-fun FlowContent.image(image: ImageView) {
+fun FlowContent.image(viewModel: ImageViewViewModel) {
     figure {
-        p(classes = "has-text-weight-bold") { +image.title }
-        img {
-            src = image.content
-        }
+        style = "width: fit-content;"
+
+        p(classes = "has-text-weight-bold") { +viewModel.title }
+        img { src = viewModel.content }
         figcaption {
-            +image.description
+            +viewModel.name
+            if (!viewModel.description.isNullOrBlank()) {
+                br
+                +viewModel.description
+            }
         }
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Modal.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Modal.kt
@@ -1,0 +1,26 @@
+package nl.avisi.structurizr.site.generatr.site.views
+
+import kotlinx.html.FlowContent
+import kotlinx.html.button
+import kotlinx.html.div
+import kotlinx.html.id
+import kotlinx.html.onClick
+
+fun FlowContent.modal(dialogId: String, block: FlowContent.() -> Unit) {
+    div(classes = "modal") {
+        id = dialogId
+
+        div(classes = "modal-background") {
+            onClick = "closeModal('$dialogId')"
+        }
+        div(classes = "modal-content") {
+            div(classes = "box") {
+                block()
+            }
+        }
+        button(classes = "modal-close is-large") {
+            attributes["aria-label"] = "close"
+            onClick = "closeModal('$dialogId')"
+        }
+    }
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -20,6 +20,7 @@ private fun HTML.headFragment(viewModel: PageViewModel) {
         link(rel = "stylesheet", href = CDN.bulmaCss())
         link(rel = "stylesheet", href = "../" + "/style.css".asUrlToFile(viewModel.url))
         link(rel = "stylesheet", href = "./" + "/style-branding.css".asUrlToFile(viewModel.url))
+        script(type = ScriptType.textJavaScript, src = "../" + "/modal.js".asUrlToFile(viewModel.url)) { }
         script(type = ScriptType.textJavaScript, src = "../" + "/svg-modal.js".asUrlToFile(viewModel.url)) { }
         script(type = ScriptType.textJavaScript, src = CDN.svgpanzoomJs()) { }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemComponentPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemComponentPage.kt
@@ -6,6 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemComponentPage
 fun HTML.softwareSystemComponentPage(viewModel: SoftwareSystemComponentPageViewModel) {
     if (viewModel.visible)
         softwareSystemPage(viewModel) {
+            // TODO: group by containers
             viewModel.diagrams.forEach { diagram(it) }
             viewModel.images.forEach { image(it) }
         }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDecisionsPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemDecisionsPage.kt
@@ -11,8 +11,7 @@ fun HTML.softwareSystemDecisionsPage(viewModel: SoftwareSystemDecisionsPageViewM
         redirectRelative(
             viewModel.decisionTabs.first().link.relativeHref
         )
-    }
-    else if (viewModel.visible) {
+    } else if (viewModel.visible) {
         softwareSystemPage(viewModel) {
             div(classes = "tabs") {
                 ul(classes = "m-0 is-flex-wrap-wrap is-flex-shrink-1 is-flex-grow-0") {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/softwareSystemCodePage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/softwareSystemCodePage.kt
@@ -6,6 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemCodePageViewM
 fun HTML.softwareSystemCodePage(viewModel: SoftwareSystemCodePageViewModel) {
     if (viewModel.visible) {
         softwareSystemPage(viewModel) {
+            // TODO: group by containers / components
             viewModel.images.forEach { image(it) }
         }
     } else

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -40,3 +40,7 @@ svg a:hover {
     min-height: inherit;
     max-height: inherit;
 }
+
+.modal-image {
+    object-fit: contain;
+}

--- a/src/main/resources/assets/js/modal.js
+++ b/src/main/resources/assets/js/modal.js
@@ -1,0 +1,19 @@
+function openModal(id) {
+  document.getElementById(id).classList.add('is-active');
+}
+
+function closeModal(id) {
+  window.removeEventListener('resize', resetPz);
+  document.getElementById(id).classList.remove('is-active');
+}
+
+// Add a keyboard event to close all modals
+document.addEventListener('keydown', (event) => {
+  if (event.code === 'Escape') {
+    (document.querySelectorAll('.modal') || []).forEach((modal) => {
+      if (modal.classList.contains('is-active')) {
+        closeModal(modal.id);
+      }
+    });
+  }
+});

--- a/src/main/resources/assets/js/svg-modal.js
+++ b/src/main/resources/assets/js/svg-modal.js
@@ -8,11 +8,11 @@ function resetPz() {
   }
 }
 
-function openModal(id, svgId) {
-  document.getElementById(id).classList.add('is-active')
+function openSvgModal(id, svgId) {
+  openModal(id);
 
   const svgElement = document.getElementById(svgId).firstElementChild;
-  svgElement.classList.add('modal-svg')
+  svgElement.classList.add('modal-svg');
 
   pz = svgPanZoom(svgElement, {
     zoomEnabled: true,
@@ -28,21 +28,9 @@ function openModal(id, svgId) {
   window.addEventListener('resize', resetPz);
 }
 
-function closeModal(id) {
+function closeSvgModal(id) {
   if (pz) {
     pz.destroy();
   }
-  window.removeEventListener('resize', resetPz);
-  document.getElementById(id).classList.remove('is-active');
+  closeModal(id);
 }
-
-// Add a keyboard event to close all modals
-document.addEventListener('keydown', (event) => {
-  if (event.code === 'Escape') {
-    (document.querySelectorAll('.modal') || []).forEach((modal) => {
-      if (modal.classList.contains('is-active')) {
-        closeModal(modal.id);
-      }
-    });
-  }
-});

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/AsciidocToHtmlTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/AsciidocToHtmlTest.kt
@@ -211,7 +211,7 @@ class AsciidocToHtmlTest : ViewModelTest() {
                  <svg viewBox="0 0 800 900"></svg>
                 </div>
                 <figcaption>
-                 <a onclick="openModal('SystemLandscape-modal', 'SystemLandscape-svg')">System Landscape Diagram</a>
+                 <a onclick="openSvgModal('SystemLandscape-modal', 'SystemLandscape-svg')">System Landscape Diagram</a>
                 </figcaption>
                </figure>
                <div class="modal" id="SystemLandscape-modal">

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ImageViewViewModelTest.kt
@@ -1,0 +1,31 @@
+package nl.avisi.structurizr.site.generatr.site.model
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.structurizr.model.SoftwareSystem
+import kotlin.test.Test
+
+class ImageViewViewModelTest : ViewModelTest() {
+    private val generatorContext = generatorContext()
+    private val softwareSystem: SoftwareSystem = generatorContext.workspace.model.addSoftwareSystem("Software system 1")
+    private val container = softwareSystem.addContainer("Container 1")
+    private val component = container.addComponent("Component 1")
+
+    @Test
+    fun `image name for software system`() {
+        val imageView = ImageViewViewModel(createImageView(generatorContext.workspace, softwareSystem))
+        assertThat(imageView.name).isEqualTo("Software system 1 - Containers")
+    }
+
+    @Test
+    fun `image name for container`() {
+        val imageView = ImageViewViewModel(createImageView(generatorContext.workspace, container))
+        assertThat(imageView.name).isEqualTo("Software system 1 - Container 1 - Components")
+    }
+
+    @Test
+    fun `image name for component`() {
+        val imageView = ImageViewViewModel(createImageView(generatorContext.workspace, component))
+        assertThat(imageView.name).isEqualTo("Software system 1 - Container 1 - Component 1 - Code")
+    }
+}

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtmlTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MarkdownToHtmlTest.kt
@@ -293,7 +293,7 @@ class MarkdownToHtmlTest : ViewModelTest() {
                     <svg viewBox="0 0 800 900"></svg>
                    </div>
                    <figcaption>
-                    <a onclick="openModal('SystemLandscape-modal', 'SystemLandscape-svg')">System Landscape Diagram</a>
+                    <a onclick="openSvgModal('SystemLandscape-modal', 'SystemLandscape-svg')">System Landscape Diagram</a>
                    </figcaption>
                   </figure>
                   <div class="modal" id="SystemLandscape-modal">

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemCodePageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemCodePageViewModelTest.kt
@@ -29,7 +29,7 @@ class SoftwareSystemCodePageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.visible).isTrue()
         assertThat(viewModel.images).hasSize(1)
-        assertThat(viewModel.images.single()).isEqualTo(imageView)
+        assertThat(viewModel.images.single().imageView).isEqualTo(imageView)
     }
 
     @Test

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemComponentPageViewModelTest.kt
@@ -36,6 +36,7 @@ class SoftwareSystemComponentPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "component-1",
                 "Software system - Backend - Components",
+                "Component view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/component-1.svg"),
@@ -45,6 +46,7 @@ class SoftwareSystemComponentPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "component-2",
                 "Software system - Backend - Components",
+                "Component view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/component-2.svg"),
@@ -60,7 +62,7 @@ class SoftwareSystemComponentPageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.visible).isTrue()
         assertThat(viewModel.images).hasSize(1)
-        assertThat(viewModel.images.single()).isEqualTo(imageView)
+        assertThat(viewModel.images.single().imageView).isEqualTo(imageView)
     }
 
     @Test

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
@@ -35,6 +35,7 @@ class SoftwareSystemContainerPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "container-1",
                 "Software system - Containers",
+                "Container view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/container-1.svg"),
@@ -44,6 +45,7 @@ class SoftwareSystemContainerPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "container-2",
                 "Software system - Containers",
+                "Container view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/container-2.svg"),
@@ -59,7 +61,7 @@ class SoftwareSystemContainerPageViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.visible).isTrue()
         assertThat(viewModel.images).hasSize(1)
-        assertThat(viewModel.images.single()).isEqualTo(imageView)
+        assertThat(viewModel.images.single().imageView).isEqualTo(imageView)
     }
 
     @Test

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
@@ -22,6 +22,7 @@ class SoftwareSystemContextPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "context-1",
                 "Software system - System Context",
+                "System context view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/context-1.svg"),
@@ -31,6 +32,7 @@ class SoftwareSystemContextPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "context-2",
                 "Software system - System Context",
+                "System context view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/context-2.svg"),

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
@@ -31,6 +31,7 @@ class SoftwareSystemDeploymentPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "deployment-1",
                 "Software system - Deployment - Default",
+                "Deployment view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/deployment-1.svg"),
@@ -40,6 +41,7 @@ class SoftwareSystemDeploymentPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "deployment-2",
                 "Software system - Deployment - Default",
+                "Deployment view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/deployment-2.svg"),

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDynamicPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDynamicPageViewModelTest.kt
@@ -33,6 +33,7 @@ class SoftwareSystemDynamicPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "backend-dynamic",
                 "Backend - Dynamic",
+                "Dynamic view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/backend-dynamic.svg"),
@@ -42,6 +43,7 @@ class SoftwareSystemDynamicPageViewModelTest : ViewModelTest() {
             DiagramViewModel(
                 "frontend-dynamic",
                 "Frontend - Dynamic",
+                "Dynamic view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
                 800,
                 ImageViewModel(viewModel, "/svg/frontend-dynamic.svg"),


### PR DESCRIPTION
Make diagrams and images more consistent ~and, more importantly, link directly to diagrams / images instead of to pages when drilling down.~ 

Align name, title and description. Add modal dialog for images. 

Edit: I made this much smaller in the end, down-drilling to the actual diagram didn't worked that well with scrolling etc. 