### PR TITLE
Update to structurizr libraries 2.x

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,9 +20,9 @@ dependencies {
 
     implementation("org.eclipse.jgit:org.eclipse.jgit:6.9.0.202403050737-r")
 
-    implementation("com.structurizr:structurizr-core:1.29.0")
-    implementation("com.structurizr:structurizr-dsl:1.35.0")
-    implementation("com.structurizr:structurizr-export:1.19.0")
+    implementation("com.structurizr:structurizr-core:2.1.1")
+    implementation("com.structurizr:structurizr-dsl:2.1.1")
+    implementation("com.structurizr:structurizr-export:2.1.1")
 
     implementation("net.sourceforge.plantuml:plantuml:1.2024.3")
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -199,6 +199,7 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
         eventSockets.forEach { it.send(message) }
     }
 
+    @Suppress("UNUSED_PARAMETER", "unused")
     @WebSocket
     inner class EventSocket {
         private var session: Session? = null

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -2,7 +2,6 @@
 
 package nl.avisi.structurizr.site.generatr
 
-import com.sun.nio.file.SensitivityWatchEventModifier
 import kotlinx.cli.*
 import nl.avisi.structurizr.site.generatr.site.*
 import org.eclipse.jetty.server.Server
@@ -130,11 +129,10 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
         context: ContextHandler,
         @Suppress("SameParameterValue") pathSpec: String
     ) =
-        WebSocketUpgradeHandler.from(server, context)
-            .configure { container ->
-                container.idleTimeout = Duration.ZERO
-                container.addMapping(pathSpec) { _, _, _ -> EventSocket() }
-            }
+        WebSocketUpgradeHandler.from(server, context) { container ->
+            container.idleTimeout = Duration.ZERO
+            container.addMapping(pathSpec) { _, _, _ -> EventSocket() }
+        }
 
     private fun startWatchService(): WatchService {
         val path = File(workspaceFile).absoluteFile.parentFile.toPath()
@@ -193,8 +191,7 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
                 StandardWatchEventKinds.ENTRY_CREATE,
                 StandardWatchEventKinds.ENTRY_DELETE,
                 StandardWatchEventKinds.ENTRY_MODIFY
-            ),
-            SensitivityWatchEventModifier.HIGH
+            )
         )
     }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
@@ -9,7 +9,7 @@ import com.structurizr.view.ViewSet
 val Workspace.includedSoftwareSystems: List<SoftwareSystem>
     get() = model.softwareSystems.filter {
         val externalTag = views.configuration.properties.getOrDefault("generatr.site.externalTag", null)
-        it.location != Location.External && if (externalTag != null) !it.tags.contains(externalTag) else true
+        if (externalTag != null) !it.tags.contains(externalTag) else true
     }
 
 fun Workspace.hasImageViews(id: String) = views.imageViews.any { it.elementId == id }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/DiagramGenerator.kt
@@ -10,7 +10,7 @@ import net.sourceforge.plantuml.FileFormatOption
 import net.sourceforge.plantuml.SourceStringReader
 import java.io.ByteArrayOutputStream
 import java.io.File
-import java.net.URL
+import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
 
 fun generateDiagrams(workspace: Workspace, exportDir: File) {
@@ -119,7 +119,7 @@ private object IncludeCache {
     }
 
     private fun downloadIncludedFile(includedFile: String, cachedFile: File) {
-        URL(includedFile).openStream().use { inputStream ->
+        URI(includedFile).toURL().openStream().use { inputStream ->
             cachedFile.outputStream().use { outputStream ->
                 inputStream.copyTo(outputStream)
             }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/PlantUmlExporterTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/PlantUmlExporterTest.kt
@@ -291,42 +291,6 @@ class PlantUmlExporterTest {
     }
 
     @Test
-    fun `external software system (outside enterprise boundary) (c4)`() {
-        val workspace = createWorkspaceWithTwoSystems()
-        workspace.model.softwareSystems.single { it.name == "System 2" }.location = Location.External
-
-        val diagram = C4PlantUmlExporterWithElementLinks(workspace, "/landscape/")
-            .export(workspace.views.systemContextViews.first())
-
-        assertThat(diagram.definition.withoutC4HeaderAndFooter()).isEqualTo(
-            """
-            System(System1, "System 1", ${'$'}descr="", ${'$'}tags="", ${'$'}link="")
-            System_Ext(System2, "System 2", ${'$'}descr="", ${'$'}tags="", ${'$'}link="")
-
-            Rel(System2, System1, "uses", ${'$'}techn="", ${'$'}tags="", ${'$'}link="")
-            """.trimIndent()
-        )
-    }
-
-    @Test
-    fun `external software system (outside enterprise boundary) (structurizr)`() {
-        val workspace = createWorkspaceWithTwoSystems()
-        workspace.model.softwareSystems.single { it.name == "System 2" }.location = Location.External
-
-        val diagram = StructurizrPlantUmlExporterWithElementLinks(workspace, "/landscape/")
-            .export(workspace.views.systemContextViews.first())
-
-        assertThat(diagram.definition.withoutStructurizrHeaderAndFooter()).isEqualTo(
-            """
-            rectangle "==System 1\n<size:10>[Software System]</size>" <<System1>> as System1
-            rectangle "==System 2\n<size:10>[Software System]</size>" <<System2>> as System2
-
-            System2 .[#707070,thickness=2].> System1 : "<color:#707070>uses"
-            """.trimIndent()
-        )
-    }
-
-    @Test
     fun `external software system (declared external by tag) (c4)`() {
         val workspace = createWorkspaceWithTwoSystems()
         workspace.views.configuration.addProperty("generatr.site.externalTag", "External System")

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/IndexingTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/IndexingTest.kt
@@ -2,6 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
 import assertk.assertions.containsAll
+import assertk.assertions.containsAtLeast
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
@@ -51,7 +52,7 @@ class IndexingTest : ViewModelTest() {
         workspace.documentation.addSection(createSection("# Landscape\nMore info"))
         val documents = workspaceSections(workspace.documentation, this.pageViewModel())
 
-        assertThat(documents).containsAll(
+        assertThat(documents).containsAtLeast(
             Document(
                 "../landscape/",
                 "Workspace Documentation",
@@ -73,7 +74,7 @@ class IndexingTest : ViewModelTest() {
         workspace.documentation.addDecision(createDecision())
         val documents = workspaceDecisions(workspace.documentation, this.pageViewModel())
 
-        assertThat(documents).containsAll(
+        assertThat(documents).containsAtLeast(
             Document(
                 "../decisions/1/",
                 "Workspace Decision",
@@ -261,7 +262,7 @@ class IndexingTest : ViewModelTest() {
         }
         val documents = softwareSystemDecisions(workspace.model.softwareSystems.single(), this.pageViewModel())
 
-        assertThat(documents).containsAll(
+        assertThat(documents).containsAtLeast(
             Document(
                 "../software-system-1/decisions/1/",
                 "Decision",
@@ -304,7 +305,7 @@ class IndexingTest : ViewModelTest() {
         }
         val documents = softwareSystemSections(workspace.model.softwareSystems.single(), this.pageViewModel())
 
-        assertThat(documents).containsAll(
+        assertThat(documents).containsAtLeast(
             Document(
                 "../software-system-1/sections/2/",
                 "Documentation",

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/MenuViewModelTest.kt
@@ -7,7 +7,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isTrue
 import com.structurizr.documentation.Decision
 import com.structurizr.documentation.Format
-import com.structurizr.model.Location
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -121,29 +120,6 @@ class MenuViewModelTest : ViewModelTest() {
             )
         )
             .let { assertThat(it.softwareSystemItems[0].active).isTrue() }
-    }
-
-    @Test
-    fun `show menu entries for software systems with an unspecified location`() {
-        val generatorContext = generatorContext(branches = listOf("main", "branch-2"), currentBranch = "main")
-        generatorContext.workspace.model.addSoftwareSystem(Location.Unspecified, "System 1", "")
-
-        MenuViewModel(generatorContext, createPageViewModel(generatorContext, url = HomePageViewModel.url()))
-            .let {
-                assertThat(it.softwareSystemItems).hasSize(1)
-                assertThat(it.softwareSystemItems[0].title).isEqualTo("System 1")
-            }
-    }
-
-    @Test
-    fun `do not show menu entries for software systems with an external location (outside enterprise boundary)`() {
-        val generatorContext = generatorContext(branches = listOf("main", "branch-2"), currentBranch = "main")
-        generatorContext.workspace.model.addSoftwareSystem(Location.External, "System 1", "")
-
-        MenuViewModel(generatorContext, createPageViewModel(generatorContext, url = HomePageViewModel.url()))
-            .let {
-                assertThat(it.softwareSystemItems).hasSize(0)
-            }
     }
 
     @Test

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModelTest.kt
@@ -7,7 +7,6 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import com.structurizr.documentation.Format
 import com.structurizr.documentation.Section
-import com.structurizr.model.Location
 import org.junit.jupiter.api.Test
 
 class SearchViewModelTest : ViewModelTest() {
@@ -59,18 +58,6 @@ class SearchViewModelTest : ViewModelTest() {
 
         assertThat(viewModel.documents.map { it.type })
             .containsExactly("Context views")
-    }
-
-    @Test
-    fun `indexes no external software system (outside enterprise boundary)`() {
-        val generatorContext = generatorContext()
-        generatorContext.workspace.apply {
-            model.addSoftwareSystem("Software system").apply { location = Location.External }
-        }
-        val viewModel = SearchViewModel(generatorContext)
-
-        assertThat(viewModel.documents.map { it.type })
-            .isEmpty()
     }
 
     @Test

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDependenciesPageViewModelTest.kt
@@ -2,7 +2,6 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
 import assertk.assertions.*
-import com.structurizr.model.Location
 import kotlin.test.Test
 
 class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
@@ -88,20 +87,6 @@ class SoftwareSystemDependenciesPageViewModelTest : ViewModelTest() {
         // Outbound Table
         assertThat(viewModel.dependenciesOutboundTable.bodyRows.extractTitle())
             .containsExactly("Software system 2")
-    }
-
-    @Test
-    fun `dependencies from and to external systems (outside enterprise boundary)`() {
-        val externalSystem = generatorContext.workspace.model
-            .addSoftwareSystem(Location.External, "External system", "")
-        externalSystem.uses(softwareSystem1, "Uses", "REST")
-        softwareSystem1.uses(externalSystem, "Uses", "REST")
-        val viewModel = SoftwareSystemDependenciesPageViewModel(generatorContext, softwareSystem1)
-
-        assertThat(viewModel.dependenciesInboundTable.bodyRows[0].columns[0])
-            .isEqualTo(TableViewModel.TextCellViewModel("External system (External)", isHeader = true, greyText = true))
-        assertThat(viewModel.dependenciesOutboundTable.bodyRows[0].columns[0])
-            .isEqualTo(TableViewModel.TextCellViewModel("External system (External)", isHeader = true, greyText = true))
     }
 
     @Test

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemsPageViewModelTest.kt
@@ -3,7 +3,6 @@ package nl.avisi.structurizr.site.generatr.site.model
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
-import com.structurizr.model.Location
 import kotlin.test.Test
 
 class SoftwareSystemsPageViewModelTest : ViewModelTest() {
@@ -66,16 +65,6 @@ class SoftwareSystemsPageViewModelTest : ViewModelTest() {
             .map { it.link.title }
 
         assertThat(names).containsExactly(system1.name, system2.name)
-    }
-
-    @Test
-    fun `external systems have grey text (outside enterprise boundary)`() {
-        val generatorContext = generatorContext()
-        generatorContext.workspace.model.addSoftwareSystem(Location.External, "system 1", "System 1 description")
-        val viewModel = SoftwareSystemsPageViewModel(generatorContext)
-
-        assertThat(viewModel.softwareSystemsTable.bodyRows[0].columns[0])
-            .isEqualTo(TableViewModel.TextCellViewModel("system 1 (External)", isHeader = true, greyText = true))
     }
 
     @Test

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/TableViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/TableViewModelTest.kt
@@ -2,6 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
 import assertk.assertions.containsAll
+import assertk.assertions.containsAtLeast
 import kotlin.test.Test
 
 class TableViewModelTest : ViewModelTest() {
@@ -16,7 +17,7 @@ class TableViewModelTest : ViewModelTest() {
             headerRow(headerCell("1"), headerCell("2"), headerCell("3"))
         }
 
-        assertThat(viewModel.headerRows).containsAll(
+        assertThat(viewModel.headerRows).containsAtLeast(
             TableViewModel.RowViewModel(
                 listOf(
                     TableViewModel.TextCellViewModel("1", isHeader = true),
@@ -33,7 +34,7 @@ class TableViewModelTest : ViewModelTest() {
             headerRow(headerCell("1", greyText = true))
         }
 
-        assertThat(viewModel.headerRows).containsAll(
+        assertThat(viewModel.headerRows).containsAtLeast(
             TableViewModel.RowViewModel(
                 listOf(
                     TableViewModel.TextCellViewModel("1", isHeader = true, greyText = true),
@@ -48,7 +49,7 @@ class TableViewModelTest : ViewModelTest() {
             bodyRow(cell("1"), cell("2"), cell("3"))
         }
 
-        assertThat(viewModel.bodyRows).containsAll(
+        assertThat(viewModel.bodyRows).containsAtLeast(
             TableViewModel.RowViewModel(
                 listOf(
                     TableViewModel.TextCellViewModel("1", isHeader = false),
@@ -65,7 +66,7 @@ class TableViewModelTest : ViewModelTest() {
             bodyRow(cellWithLink(pageViewModel, "click me", "/decisions"))
         }
 
-        assertThat(viewModel.bodyRows).containsAll(
+        assertThat(viewModel.bodyRows).containsAtLeast(
             TableViewModel.RowViewModel(
                 listOf(
                     TableViewModel.LinkCellViewModel(
@@ -83,7 +84,7 @@ class TableViewModelTest : ViewModelTest() {
             bodyRow(headerCellWithLink(pageViewModel, "click me", "/decisions"))
         }
 
-        assertThat(viewModel.bodyRows).containsAll(
+        assertThat(viewModel.bodyRows).containsAtLeast(
             TableViewModel.RowViewModel(
                 listOf(
                     TableViewModel.LinkCellViewModel(
@@ -101,7 +102,7 @@ class TableViewModelTest : ViewModelTest() {
             bodyRow(cellWithExternalLink("Temporary URI", "https://tempuri.org/"))
         }
 
-        assertThat(viewModel.bodyRows).containsAll(
+        assertThat(viewModel.bodyRows).containsAtLeast(
             TableViewModel.RowViewModel(
                 listOf(
                     TableViewModel.ExternalLinkCellViewModel(
@@ -119,7 +120,7 @@ class TableViewModelTest : ViewModelTest() {
             bodyRow(cellWithIndex("1"))
         }
 
-        assertThat(viewModel.bodyRows).containsAll(
+        assertThat(viewModel.bodyRows).containsAtLeast(
             TableViewModel.RowViewModel(
                 listOf(
                     TableViewModel.TextCellViewModel(


### PR DESCRIPTION
Also resolve other deprecation warnings.

Supersedes https://github.com/avisi-cloud/structurizr-site-generatr/pull/442 , https://github.com/avisi-cloud/structurizr-site-generatr/pull/441 and https://github.com/avisi-cloud/structurizr-site-generatr/pull/440  (Dependabot will kick in again for 2.x updates after this PR has been merged)

Probably a good idea to make a release before this PR goes in.