### PR TITLE
Lower the JRE version requirement to version 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     kotlin("jvm") version "1.9.23"
     kotlin("plugin.serialization") version "1.9.23"
@@ -52,6 +54,13 @@ application {
 
 kotlin {
     jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks {


### PR DESCRIPTION
Since we don't use any modern JRE features for this tool, there's no need for it to always require the newest JRE to be installed. Therefore it seems like a good idea to lower the requirement to the lowest JRE version that is required by the libraries this tool uses. This happens to be version 17.

I made sure this works, by locally creating a distribution and running it using Java 17.