### PR TITLE
fix: the header branch selector now properly encode the branch name as an URI

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModel.kt
@@ -1,11 +1,13 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import nl.avisi.structurizr.site.generatr.site.asUrlToDirectory
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 data class BranchHomeLinkViewModel(
     private val pageViewModel: PageViewModel,
     private val branchName: String
 ) {
     val title get() = branchName
-    val relativeHref get() = HomePageViewModel.url().asUrlToDirectory(pageViewModel.url) + "../$branchName/"
+    val relativeHref get() = HomePageViewModel.url().asUrlToDirectory(pageViewModel.url) + "../${URLEncoder.encode(branchName, StandardCharsets.UTF_8)}/"
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/BranchHomeLinkViewModelTest.kt
@@ -29,4 +29,20 @@ class BranchHomeLinkViewModelTest : ViewModelTest() {
         assertThat(viewModel.relativeHref)
             .isEqualTo("./../master/")
     }
+
+    @Test
+    fun `title is branch name when branch name contains slash`() {
+        val viewModel = BranchHomeLinkViewModel(pageViewModel(), "feat/branch-1")
+
+        assertThat(viewModel.title)
+            .isEqualTo("feat/branch-1")
+    }
+
+    @Test
+    fun `relative href from home when branch name contains slash`() {
+        val viewModel = BranchHomeLinkViewModel(pageViewModel("/"), "feat/branch-1")
+
+        assertThat(viewModel.relativeHref)
+            .isEqualTo("./../feat%2Fbranch-1/")
+    }
 }


### PR DESCRIPTION
Fixes #492
I included some new tests to check the encoding, using the one of the most character in branch names "/".