### PR TITLE
Update dependency bulma to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "structurizr-site-generatr",
     "dependencies": {
-        "bulma": "0.9.4",
+        "bulma": "1.0.0",
         "katex": "0.16.10",
         "lunr": "2.3.9",
         "lunr-languages": "1.14.0",

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -6,6 +6,7 @@ import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
 
 fun HTML.page(viewModel: PageViewModel, block: DIV.() -> Unit) {
     attributes["lang"] = "en"
+    attributes["data-theme"] = "light"
     classes = setOf("has-background-light")
 
     headFragment(viewModel)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Table.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Table.kt
@@ -4,7 +4,7 @@ import kotlinx.html.*
 import nl.avisi.structurizr.site.generatr.site.model.TableViewModel
 
 fun FlowContent.table(viewModel: TableViewModel) {
-    table {
+    table (classes = "table is-fullwidth") {
         thead {
             viewModel.headerRows.forEach {
                 row(it)

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -64,6 +64,10 @@ svg a:hover {
     object-fit: contain;
 }
 
+a.navbar-item:hover {
+    background-color: transparent;
+}
+
 .tabs li.is-active a {
     color: #485fc7;
     border-bottom-color: #485fc7;

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -7,6 +7,10 @@
     border-right: 1px solid #cccccc;
 }
 
+.menu-list a {
+    background-color: transparent;
+}
+
 .is-front-centered {
     width: 40%;
     margin-left: 30%;
@@ -41,6 +45,26 @@ svg a:hover {
     max-height: inherit;
 }
 
+.content h1,
+.content h1 a,
+.content h2,
+.content h2 a,
+.content h3,
+.content h3 a,
+.content h4,
+.content h4 a,
+.content h5,
+.content h5 a,
+.content h6 ,
+.content h6 a {
+    color: #485fc7; /* Pre Bulma 1.x colour code for headers, tabs and links */
+}
+
 .modal-image {
     object-fit: contain;
+}
+
+.tabs li.is-active a {
+    color: #485fc7;
+    border-bottom-color: #485fc7;
 }


### PR DESCRIPTION
This PR was originally [this link](https://github.com/avisi-cloud/structurizr-site-generatr/pull/464) but there were still some styling problems in the original PR. 

This PR features:
- Original first two commits by renovate and @dirkgroot 
- Colour of headers and links fixed (amended to the commit by @dirkgroot)
- Tables now scale to full width
- Navbar link background colours are now transparent again