### PR TITLE
Fix not every link colour being consistent

### DIFF
--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -45,18 +45,7 @@ svg a:hover {
     max-height: inherit;
 }
 
-.content h1,
-.content h1 a,
-.content h2,
-.content h2 a,
-.content h3,
-.content h3 a,
-.content h4,
-.content h4 a,
-.content h5,
-.content h5 a,
-.content h6 ,
-.content h6 a {
+a {
     color: #485fc7; /* Pre Bulma 1.x colour code for headers, tabs and links */
 }
 


### PR DESCRIPTION
I've found some areas of structurizr where the colour code isn't the standard #485fc7. This PR makes the colouring of the Big Bank Plc. consistent again.