### PR TITLE
Draft: Implement dark mode when preferred in settings

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -27,6 +27,7 @@ fun copySiteWideAssets(exportDir: File) {
     copySiteWideAsset(exportDir, "/css/treeview.css")
     copySiteWideAsset(exportDir, "/js/treeview.js")
     copySiteWideAsset(exportDir, "/js/katex-render.js")
+    copySiteWideAsset(exportDir, "/js/is-color-scheme-light.js")
 }
 
 private fun copySiteWideAsset(exportDir: File, asset: String) {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -6,8 +6,6 @@ import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
 
 fun HTML.page(viewModel: PageViewModel, block: DIV.() -> Unit) {
     attributes["lang"] = "en"
-    attributes["data-theme"] = "light"
-    classes = setOf("has-background-light")
 
     headFragment(viewModel)
     bodyFragment(viewModel, block)
@@ -15,6 +13,7 @@ fun HTML.page(viewModel: PageViewModel, block: DIV.() -> Unit) {
 
 private fun HTML.headFragment(viewModel: PageViewModel) {
     head {
+        script(type = ScriptType.textJavaScript, src = "/is-color-scheme-light.js") { }
         meta(charset = "utf-8")
         meta(name = "viewport", content = "width=device-width, initial-scale=1")
         title { +viewModel.pageTitle }
@@ -59,7 +58,7 @@ private fun HTML.bodyFragment(viewModel: PageViewModel, block: DIV.() -> Unit) {
         div(classes = "site-layout") {
             id = "site"
             menu(viewModel.menu, viewModel.includeTreeview)
-            div(classes = "container is-fluid has-background-white") {
+            div(classes = "container is-fluid") {
                 block()
             }
         }

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -61,3 +61,18 @@ a.navbar-item:hover {
     color: #485fc7;
     border-bottom-color: #485fc7;
 }
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        .tabs li a {
+            border-bottom-color: #696969;
+        }
+        .tabs li.is-active a {
+            color: #7585ff;
+            border-bottom-color: #7585ff;
+        }
+        .text {
+            fill: #ebecf0
+        }
+    }
+}

--- a/src/main/resources/assets/js/is-color-scheme-light.js
+++ b/src/main/resources/assets/js/is-color-scheme-light.js
@@ -1,0 +1,9 @@
+(() => {
+    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+        document.documentElement.setAttribute('data-theme', 'light');
+        document.documentElement.setAttribute('class', 'has-background-light');
+    } else {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        document.documentElement.setAttribute('class', 'has-background-dark');
+    }
+})()


### PR DESCRIPTION
In this PR, dark mode will be applied when the user has set dark mode as their preferred appearance. ![This is how it looks.](https://github.com/avisi-cloud/structurizr-site-generatr/assets/94041537/96679cce-ae44-49ae-9902-15cdb17f020e)

There are still some features and/or issues that I have not added in this push:

- PlantUML diagrams don't convert to dark mode. Some rectangles or shapes have a preset colour that don't change when dark mode is preferred. A possible fix for this is making these shapes transparent, but I'm not sure if this is possible. I'll try my best and find something for this though :)
- There is not a possibility yet to change the light/dark mode on the go. I'm thinking I can make a button for this on the navbar somewhere. I'll include this in a next push.
- The colour of <li.is-active a> links is different than other links. I'll change this in the next push too for consistency reasons.
