### PR TITLE
Fix multiple tables scaling incorrectly

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Table.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Table.kt
@@ -4,15 +4,32 @@ import kotlinx.html.*
 import nl.avisi.structurizr.site.generatr.site.model.TableViewModel
 
 fun FlowContent.table(viewModel: TableViewModel) {
-    table (classes = "table is-fullwidth") {
-        thead {
-            viewModel.headerRows.forEach {
-                row(it)
+    viewModel.headerRows.forEach { rowViewModel ->
+        if (rowViewModel.columns.size > 2) {
+            table (classes = "table is-fullwidth large-table") {
+                thead {
+                    viewModel.headerRows.forEach {
+                        row(it)
+                    }
+                }
+                tbody {
+                    viewModel.bodyRows.forEach {
+                        row(it)
+                    }
+                }
             }
-        }
-        tbody {
-            viewModel.bodyRows.forEach {
-                row(it)
+        } else {
+            table (classes = "table is-fullwidth") {
+                thead {
+                    viewModel.headerRows.forEach {
+                        row(it)
+                    }
+                }
+                tbody {
+                    viewModel.bodyRows.forEach {
+                        row(it)
+                    }
+                }
             }
         }
     }

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -61,3 +61,7 @@ a.navbar-item:hover {
     color: #485fc7;
     border-bottom-color: #485fc7;
 }
+
+.large-table {
+    table-layout: fixed;
+}


### PR DESCRIPTION
This PR sets the table layout to fixed whenever a table has more than two columns. I'd love to hear your thoughts on this change.

Before:
![Screenshot 2024-06-13 at 16 06 22](https://github.com/avisi-cloud/structurizr-site-generatr/assets/94041537/1145ea36-4e6b-4982-9c82-21e477eb7bad)

After:
![Screenshot 2024-06-13 at 11 34 34](https://github.com/avisi-cloud/structurizr-site-generatr/assets/94041537/eb0c47e6-0ef6-4618-aa93-ba4e22d9aa1f)

Tables with less than two columns don't have a fixed table layout:
![Screenshot 2024-06-13 at 16 08 13](https://github.com/avisi-cloud/structurizr-site-generatr/assets/94041537/cc100a97-7872-4084-8fc8-8a64379600b7)

But if this needs to change: this is what it would look like if the same table has a fixed table layout: 
![Screenshot 2024-06-13 at 11 34 40](https://github.com/avisi-cloud/structurizr-site-generatr/assets/94041537/0425e30b-2792-4518-a40c-ab6ae88ab2a1)
