### PR TITLE
fix: ending slash are preserved on links

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ToHtml.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ToHtml.kt
@@ -132,9 +132,12 @@ private class CustomLinkResolver(private val pageViewModel: PageViewModel) : Lin
         }
         if (link.url.matches("https?://.*".toRegex()))
             return link
-
+        var url =  "/${link.url.dropWhile { it == '/' }}"
+            .asUrlToFile(pageViewModel.url)
+        // Make sure that the link ending slash is being preserved
+        url = if (link.url.endsWith("/")) url.plus("/") else url
         return link.withStatus(LinkStatus.VALID)
-            .withUrl("/${link.url.dropWhile { it == '/' }}".asUrlToFile(pageViewModel.url))
+            .withUrl(url)
     }
 
     class Factory(private val viewModel: PageViewModel) : LinkResolverFactory {

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/WorkspaceDecisionPageViewModelTest.kt
@@ -33,6 +33,22 @@ class WorkspaceDecisionPageViewModelTest : ViewModelTest() {
     }
 
     @Test
+    fun `absolute link`() {
+        val decision = createDecision().apply {
+            content = """
+                [Test Link](/test/decision/2/)
+            """.trimIndent()
+        }
+        val viewModel = WorkspaceDecisionPageViewModel(generatorContext(), decision)
+
+        assertThat(viewModel.content).isEqualTo(
+            """
+                <p><a href="../../test/decision/2/">Test Link</a></p>
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun `link to other ADR`() {
         val decision = createDecision().apply {
             content = """


### PR DESCRIPTION
When creating in Markdown links they are being stripped of ending slash `/`. This creates sometimes an issues for redirects. To solve this resolver takes into account if in original link it was slash ending and make sure that after relative URL generation that slash is being preserved.