### PR TITLE
feat: make docs link to be consistent with Workspace level

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionPageViewModel.kt
@@ -16,6 +16,6 @@ class SoftwareSystemContainerSectionPageViewModel(
 
     companion object {
         fun url(container: Container, section: Section) =
-            "${url(container.softwareSystem, Tab.SECTIONS)}/${container.name.normalize()}/${section.order}"
+            "${url(container.softwareSystem, Tab.SECTIONS)}/${container.name.normalize()}/${section.contentTitle().normalize()}"
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionsPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionsPageViewModel.kt
@@ -9,7 +9,7 @@ class SoftwareSystemContainerSectionsPageViewModel(generatorContext: GeneratorCo
     SoftwareSystemPageViewModel(generatorContext, container.softwareSystem, Tab.SECTIONS) {
     override val url = url(container)
     val sectionsTable = createSectionsTableViewModel(container.documentation.sections, dropFirst = false) {
-        "$url/${it.order}"
+        "$url/${it.contentTitle().normalize()}"
     }
 
     val visible = container.hasSections()

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModel.kt
@@ -2,6 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.documentation.Section
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.normalize
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemSectionPageViewModel(
@@ -15,6 +16,6 @@ class SoftwareSystemSectionPageViewModel(
 
     companion object {
         fun url(softwareSystem: SoftwareSystem, section: Section) =
-            "${url(softwareSystem, Tab.SECTIONS)}/${section.order}"
+            "${url(softwareSystem, Tab.SECTIONS)}/${section.contentTitle().normalize()}"
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModel.kt
@@ -3,12 +3,13 @@ package nl.avisi.structurizr.site.generatr.site.model
 import com.structurizr.model.SoftwareSystem
 import nl.avisi.structurizr.site.generatr.hasContainerDocumentationSections
 import nl.avisi.structurizr.site.generatr.hasDocumentationSections
+import nl.avisi.structurizr.site.generatr.normalize
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 class SoftwareSystemSectionsPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
     SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.SECTIONS) {
     val sectionsTable = createSectionsTableViewModel(softwareSystem.documentation.sections) {
-        "$url/${it.order}"
+        "$url/${it.contentTitle().normalize()}"
     }
 
     private val containerSectionsVisible = softwareSystem.hasContainerDocumentationSections()

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionPageViewModelTest.kt
@@ -19,7 +19,7 @@ class SoftwareSystemContainerSectionPageViewModelTest : ViewModelTest() {
         val viewModel = SoftwareSystemContainerSectionPageViewModel(generatorContext, container, section)
 
         assertThat(SoftwareSystemContainerSectionPageViewModel.url(container, section))
-            .isEqualTo("/${softwareSystem.name.normalize()}/sections/${container.name.normalize()}/${section.order}")
+            .isEqualTo("/${softwareSystem.name.normalize()}/sections/${container.name.normalize()}/${section.contentTitle().normalize()}")
         assertThat(viewModel.url)
             .isEqualTo(SoftwareSystemContainerSectionPageViewModel.url(container, section))
     }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionsPageViewModelTest.kt
@@ -35,7 +35,7 @@ class SoftwareSystemContainerSectionsPageViewModelTest : ViewModelTest() {
                     LinkViewModel(
                         viewModel,
                         "Content",
-                        "/software-system/sections/api-application/1"
+                        "/software-system/sections/api-application/content"
                     )
                 )
         }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionPageViewModelTest.kt
@@ -16,7 +16,7 @@ class SoftwareSystemSectionPageViewModelTest : ViewModelTest() {
         val viewModel = SoftwareSystemSectionPageViewModel(generatorContext, softwareSystem, section)
 
         assertThat(SoftwareSystemSectionPageViewModel.url(softwareSystem, section))
-            .isEqualTo("/${softwareSystem.name.normalize()}/sections/${section.order}")
+            .isEqualTo("/${softwareSystem.name.normalize()}/sections/${section.contentTitle().normalize()}")
         assertThat(viewModel.url)
             .isEqualTo(SoftwareSystemSectionPageViewModel.url(softwareSystem, section))
     }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModelTest.kt
@@ -28,7 +28,7 @@ class SoftwareSystemSectionsPageViewModelTest : ViewModelTest() {
         assertThat(viewModel.sectionsTable)
             .isEqualTo(
                 viewModel.createSectionsTableViewModel(softwareSystem.documentation.sections) {
-                    "/${softwareSystem.name.normalize()}/sections/2"
+                    "/${softwareSystem.name.normalize()}/sections/${it.contentTitle().normalize()}"
                 }
             )
     }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModelTest.kt
@@ -1,6 +1,9 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
+import assertk.all
 import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.index
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import nl.avisi.structurizr.site.generatr.normalize
@@ -20,17 +23,22 @@ class SoftwareSystemSectionsPageViewModelTest : ViewModelTest() {
 
     @Test
     fun `sections table`() {
-        listOf("Section 0000", "Section 0001")
+        listOf("# Section 0000", "# Section 0001")
             .forEach { softwareSystem.documentation.addSection(createSection(it)) }
 
         val viewModel = SoftwareSystemSectionsPageViewModel(generatorContext, softwareSystem)
 
-        assertThat(viewModel.sectionsTable)
-            .isEqualTo(
-                viewModel.createSectionsTableViewModel(softwareSystem.documentation.sections) {
-                    "/${softwareSystem.name.normalize()}/sections/${it.contentTitle().normalize()}"
-                }
-            )
+        assertThat(viewModel.sectionsTable.bodyRows).all {
+            hasSize(1)
+            index(0).transform { (it.columns[1] as TableViewModel.LinkCellViewModel).link }
+                .isEqualTo(
+                    LinkViewModel(
+                        viewModel,
+                        "Section 0001",
+                        "/software-system/sections/section-0001"
+                    )
+                )
+        }
     }
 
     @Test


### PR DESCRIPTION
Hi !

We saw `docs` inconsistent behavior of links between Workspace, Software System and Container.

Today links for docs on the examples are: 
* /{section.contentTitle}/ - Workspace Docs
* /{softwareSystem}/sections/{section.order}/ - Software System Docs - because the first *.md document is used for `Info` page then while no. is `1` but link is `/2/` because it's second document not first so this is already misalinged. But it's also inconsistent with Workspace dos which are based on contentTitle.
*  /{softwareSystem}/sections/{component}/{section.order} - Component Docs

This PR propose to make it always based on Content title (so it's also SEO friendly if anyone needs that).
* /{section.contentTitle}/ - Workspace Docs
* /{softwareSystem}/sections/{section.contentTitle}/ - Software System Docs
* /{softwareSystem}/sections/{component}/{section.contentTitle} - Compoent Docs

This should make links predictable and consistent for docs on different levels.