### PR TITLE
Use invariant path separators

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/RelativeUrl.kt
@@ -8,4 +8,4 @@ fun String.asUrlToFile(relativeTo: String): String =
     if (relativeTo == this) "."
     else File(this)
         .relativeTo(File(relativeTo))
-        .toString()
+        .invariantSeparatorsPath


### PR DESCRIPTION
We don't want backslashes on Windows.

Closes https://github.com/avisi-cloud/structurizr-site-generatr/issues/506



