### PR TITLE
Avoid HTML tags in AsciiDoc titles

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ContentTitle.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ContentTitle.kt
@@ -20,17 +20,17 @@ private fun Section.markdownTitle(): String {
 
     val header = document.children.firstOrNull { it is Heading }?.let { it as Heading }
     if (header != null)
-        return header.text.toString()
+        return header.text.toString().trim()
 
     return "untitled document"
 }
 
 private fun Section.asciidocTitle(): String {
-    val options = Options.builder().safe(SafeMode.SERVER).build()
+    val options = Options.builder().safe(SafeMode.SERVER).backend("text").build()
     val document = asciidoctorWithTextConverter.load(content, options)
 
     if (document.title != null && document.title.isNotEmpty())
-        return document.title
+        return document.title.trim()
 
     return "untitled document"
 }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ContentTitleTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/ContentTitleTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.Test
 
 class ContentTitleTest {
 
@@ -49,6 +50,12 @@ class ContentTitleTest {
     @ValueSource(strings = ["= header", "== header", "=== header"])
     fun `with asciidoc heading`(content: String) {
         val section = Section(Format.AsciiDoc, content)
+        assertThat(section.contentTitle()).isEqualTo("header")
+    }
+
+    @Test
+    fun `with asciidoc heading including logo`() {
+        val section = Section(Format.AsciiDoc, "= image:logo.png[logo] header")
         assertThat(section.contentTitle()).isEqualTo("header")
     }
 }


### PR DESCRIPTION
Found this while playing with AsciiDoc examples.