### PR TITLE
fix: Fix broken Indexing with correct URLs

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModel.kt
@@ -1,16 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
-import nl.avisi.structurizr.site.generatr.site.model.indexing.home
-import nl.avisi.structurizr.site.generatr.site.model.indexing.softwareSystemComponents
-import nl.avisi.structurizr.site.generatr.site.model.indexing.softwareSystemContainers
-import nl.avisi.structurizr.site.generatr.site.model.indexing.softwareSystemContext
-import nl.avisi.structurizr.site.generatr.site.model.indexing.softwareSystemDecisions
-import nl.avisi.structurizr.site.generatr.site.model.indexing.softwareSystemHome
-import nl.avisi.structurizr.site.generatr.site.model.indexing.softwareSystemRelationships
-import nl.avisi.structurizr.site.generatr.site.model.indexing.softwareSystemSections
-import nl.avisi.structurizr.site.generatr.site.model.indexing.workspaceDecisions
-import nl.avisi.structurizr.site.generatr.site.model.indexing.workspaceSections
+import nl.avisi.structurizr.site.generatr.site.model.indexing.*
 
 class SearchViewModel(generatorContext: GeneratorContext) : PageViewModel(generatorContext) {
     override val pageSubTitle = "Search results"
@@ -36,7 +27,19 @@ class SearchViewModel(generatorContext: GeneratorContext) : PageViewModel(genera
                         addAll(softwareSystemSections(it, this@SearchViewModel))
                     }
                 }
-                .mapNotNull { it },
+                .mapNotNull { it }
+        )
+        addAll(
+            includedSoftwareSystems
+                .flatMap {
+                    buildList {
+                        it.containers.forEach {
+                            addAll(softwareSystemContainerSections(it, this@SearchViewModel))
+                            addAll(softwareSystemContainerDecisions(it, this@SearchViewModel))
+                        }
+                    }
+                }
+                .mapNotNull { it }
         )
     }.mapNotNull { it }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/SoftwareSystemContainerDecisions.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/SoftwareSystemContainerDecisions.kt
@@ -1,21 +1,22 @@
 package nl.avisi.structurizr.site.generatr.site.model.indexing
 
-import com.structurizr.model.SoftwareSystem
+import com.structurizr.model.Container
 import nl.avisi.structurizr.site.generatr.site.asUrlToDirectory
 import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
-import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemDecisionPageViewModel
+import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemContainerDecisionPageViewModel
 import nl.avisi.structurizr.site.generatr.site.model.contentText
 
-fun softwareSystemDecisions(softwareSystem: SoftwareSystem, viewModel: PageViewModel) = softwareSystem.documentation
+fun softwareSystemContainerDecisions(container: Container, viewModel: PageViewModel) = container
+    .documentation
     .decisions
     .map { decision ->
         Document(
-            SoftwareSystemDecisionPageViewModel.url(
-                softwareSystem,
+            SoftwareSystemContainerDecisionPageViewModel.url(
+                container,
                 decision
             ).asUrlToDirectory(viewModel.url),
-            "Software System Decision",
-            "${softwareSystem.name} | ${decision.title}",
+            "Container Decision",
+            "${container.name} | ${decision.title}",
             "${decision.title} ${decision.contentText()}".trim()
         )
     }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/SoftwareSystemContainerSections.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/SoftwareSystemContainerSections.kt
@@ -1,0 +1,20 @@
+package nl.avisi.structurizr.site.generatr.site.model.indexing
+
+import com.structurizr.model.Container
+import nl.avisi.structurizr.site.generatr.site.asUrlToDirectory
+import nl.avisi.structurizr.site.generatr.site.model.*
+
+fun softwareSystemContainerSections(container: Container, viewModel: PageViewModel) = container
+    .documentation
+    .sections
+    .map { section ->
+        Document(
+            SoftwareSystemContainerSectionPageViewModel.url(
+                container,
+                section
+            ).asUrlToDirectory(viewModel.url),
+            "Container Documentation",
+            "${container.name} | ${section.contentTitle()}",
+            "${section.contentTitle()} ${section.contentText()}".trim()
+        )
+    }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/SoftwareSystemSections.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/SoftwareSystemSections.kt
@@ -2,23 +2,19 @@ package nl.avisi.structurizr.site.generatr.site.model.indexing
 
 import com.structurizr.model.SoftwareSystem
 import nl.avisi.structurizr.site.generatr.site.asUrlToDirectory
-import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
-import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemPageViewModel
-import nl.avisi.structurizr.site.generatr.site.model.contentText
-import nl.avisi.structurizr.site.generatr.site.model.contentTitle
+import nl.avisi.structurizr.site.generatr.site.model.*
 
 fun softwareSystemSections(softwareSystem: SoftwareSystem, viewModel: PageViewModel) = softwareSystem.documentation
     .sections
     .drop(1) // Drop software system home
     .map { section ->
         Document(
-            "${
-                SoftwareSystemPageViewModel.url(
-                    softwareSystem,
-                    SoftwareSystemPageViewModel.Tab.HOME
-                )
-            }/sections/${section.order}".asUrlToDirectory(viewModel.url),
-            "Documentation",
+
+            SoftwareSystemSectionPageViewModel.url(
+                softwareSystem,
+                section
+            ).asUrlToDirectory(viewModel.url),
+            "Software System Documentation",
             "${softwareSystem.name} | ${section.contentTitle()}",
             "${section.contentTitle()} ${section.contentText()}".trim()
         )

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/WorkspaceDecisions.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/WorkspaceDecisions.kt
@@ -3,12 +3,14 @@ package nl.avisi.structurizr.site.generatr.site.model.indexing
 import com.structurizr.documentation.Documentation
 import nl.avisi.structurizr.site.generatr.site.asUrlToDirectory
 import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
+import nl.avisi.structurizr.site.generatr.site.model.WorkspaceDecisionPageViewModel
 import nl.avisi.structurizr.site.generatr.site.model.contentText
 
 fun workspaceDecisions(documentation: Documentation, viewModel: PageViewModel) = documentation.decisions
     .map { decision ->
         Document(
-            "/decisions/${decision.id}".asUrlToDirectory(viewModel.url),
+            WorkspaceDecisionPageViewModel.url(decision)
+                .asUrlToDirectory(viewModel.url),
             "Workspace Decision",
             decision.title,
             "${decision.title} ${decision.contentText()}".trim()

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/WorkspaceSections.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/indexing/WorkspaceSections.kt
@@ -4,6 +4,7 @@ import com.structurizr.documentation.Documentation
 import nl.avisi.structurizr.site.generatr.normalize
 import nl.avisi.structurizr.site.generatr.site.asUrlToDirectory
 import nl.avisi.structurizr.site.generatr.site.model.PageViewModel
+import nl.avisi.structurizr.site.generatr.site.model.WorkspaceDocumentationSectionPageViewModel
 import nl.avisi.structurizr.site.generatr.site.model.contentText
 import nl.avisi.structurizr.site.generatr.site.model.contentTitle
 
@@ -11,7 +12,8 @@ fun workspaceSections(documentation: Documentation, viewModel: PageViewModel) = 
     .drop(1) // Drop home
     .map { section ->
         Document(
-            "/${section.contentTitle().normalize()}".asUrlToDirectory(viewModel.url),
+            WorkspaceDocumentationSectionPageViewModel.url(section)
+                .asUrlToDirectory(viewModel.url),
             "Workspace Documentation",
             section.contentTitle(),
             "${section.contentTitle()} ${section.contentText()}".trim()

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/IndexingTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/IndexingTest.kt
@@ -265,13 +265,13 @@ class IndexingTest : ViewModelTest() {
         assertThat(documents).containsAtLeast(
             Document(
                 "../software-system-1/decisions/1/",
-                "Decision",
+                "Software System Decision",
                 "Software System 1 | Decision 1",
                 "Decision 1 Decision 1 content"
             ),
             Document(
                 "../software-system-1/decisions/2/",
-                "Decision",
+                "Software System Decision",
                 "Software System 1 | Decision 2",
                 "Decision 2 Decision 2 content"
             )
@@ -307,14 +307,14 @@ class IndexingTest : ViewModelTest() {
 
         assertThat(documents).containsAtLeast(
             Document(
-                "../software-system-1/sections/2/",
-                "Documentation",
+                "../software-system-1/sections/usage/",
+                "Software System Documentation",
                 "Software System 1 | Usage",
                 "Usage That's how it works"
             ),
             Document(
-                "../software-system-1/sections/3/",
-                "Documentation",
+                "../software-system-1/sections/history/",
+                "Software System Documentation",
                 "Software System 1 | History",
                 "History That's how we got here"
             )

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SearchViewModelTest.kt
@@ -81,6 +81,8 @@ class SearchViewModelTest : ViewModelTest() {
                 documentation.addSection(Section(Format.Markdown, "# Introduction\nSome info"))
                 addContainer("Container 1", "a container").apply {
                     addComponent("Component 1", "a component")
+                    documentation.addDecision(createDecision("1"))
+                    documentation.addSection(Section(Format.Markdown, "# Component Usage\nThat's how it works"))
                 }
                 documentation.addDecision(createDecision("1"))
                 documentation.addSection(Section(Format.Markdown, "# Usage\nThat's how it works"))
@@ -94,8 +96,10 @@ class SearchViewModelTest : ViewModelTest() {
                 "Context views",
                 "Container views",
                 "Component views",
-                "Decision",
-                "Documentation"
+                "Software System Decision",
+                "Software System Documentation",
+                "Container Documentation",
+                "Container Decision"
             )
     }
 


### PR DESCRIPTION
This PR fixes indexing that has been broken by #550 .

Also enables indexing of Container level decisions and documentation. To be fully consistent with new structure.