### PR TITLE
Always take all vertical space

### DIFF
--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -1,6 +1,13 @@
+body {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
 .site-layout {
     display: grid;
     grid-template-columns: 300px 1fr;
+    flex-grow: 1;
 }
 
 .menu {


### PR DESCRIPTION
This prevents a jumping menu border.

Before: 

![image](https://github.com/user-attachments/assets/b7c22a53-2ff5-4e68-ab0a-07e47f12fef7)

After:

![image](https://github.com/user-attachments/assets/3d8c4f6e-fc12-4095-bf6d-38ced783f004)
