### PR TITLE
Show container properties on the container components page

### DIFF
--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -48,6 +48,9 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
                 apiApplication = container "API Application" "Provides Internet banking functionality via a JSON/HTTPS API." "Java and Spring MVC" {
                     !adrs internet-banking-system/api-application/adr
                     !docs internet-banking-system/api-application/docs
+                    properties {
+                        Owner "Team 1"
+                    }
                     signinController = component "Sign In Controller" "Allows users to sign in to the Internet Banking System." "Spring MVC Rest Controller"
                     accountsSummaryController = component "Accounts Summary Controller" "Provides customers with a summary of their bank accounts." "Spring MVC Rest Controller"
                     resetPasswordController = component "Reset Password Controller" "Allows users to reset their passwords with a single use URL." "Spring MVC Rest Controller"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
@@ -3,6 +3,7 @@ package nl.avisi.structurizr.site.generatr
 import com.structurizr.Workspace
 import com.structurizr.model.Container
 import com.structurizr.model.SoftwareSystem
+import com.structurizr.model.StaticStructureElement
 import com.structurizr.view.ViewSet
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
@@ -19,8 +20,8 @@ fun Workspace.hasComponentDiagrams(container: Container) = views.componentViews.
 val SoftwareSystem.hasContainers
     get() = this.containers.isNotEmpty()
 
-val SoftwareSystem.includedProperties
-    get() = this.properties.filterNot { (name, _) -> name == "structurizr.dsl.identifier" }
+val StaticStructureElement.includedProperties
+    get() = this.properties.filterNot { setOf("structurizr", "generatr").contains(it.key.split(".").first()) }
 
 val Container.hasComponents
     get() = this.components.isNotEmpty()

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -6,6 +6,7 @@ import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
 import nl.avisi.structurizr.site.generatr.hasComponentDiagrams
 import nl.avisi.structurizr.site.generatr.hasImageViews
+import nl.avisi.structurizr.site.generatr.includedProperties
 import nl.avisi.structurizr.site.generatr.includedSoftwareSystems
 import nl.avisi.structurizr.site.generatr.site.model.*
 import nl.avisi.structurizr.site.generatr.site.views.*
@@ -174,7 +175,8 @@ private fun generateHtmlFiles(context: GeneratorContext, branchDir: File) {
             it.containers
                 .filter { container ->
                     context.workspace.hasComponentDiagrams(container) or
-                            context.workspace.hasImageViews(container.id) }
+                            container.includedProperties.isNotEmpty() or
+                                context.workspace.hasImageViews(container.id) }
                 .forEach { container ->
                     add { writeHtmlFile(branchDir, SoftwareSystemContainerComponentsPageViewModel(context, container)) } }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ContainersComponentTabViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/ContainersComponentTabViewModel.kt
@@ -3,6 +3,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 import com.structurizr.model.SoftwareSystem
 import nl.avisi.structurizr.site.generatr.hasComponentDiagrams
 import nl.avisi.structurizr.site.generatr.hasImageViews
+import nl.avisi.structurizr.site.generatr.includedProperties
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 fun SoftwareSystemPageViewModel.createContainersComponentTabViewModel(
@@ -13,6 +14,7 @@ fun SoftwareSystemPageViewModel.createContainersComponentTabViewModel(
         .containers
         .sortedBy { it.name }
         .filter { container ->
+            container.includedProperties.isNotEmpty() or
             generatorContext.workspace.hasComponentDiagrams(container) or
                     generatorContext.workspace.hasImageViews(container.id) }
         .map {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerComponentsPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerComponentsPageViewModel.kt
@@ -1,6 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.Container
+import nl.avisi.structurizr.site.generatr.includedProperties
 import nl.avisi.structurizr.site.generatr.normalize
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
@@ -16,7 +17,9 @@ class SoftwareSystemContainerComponentsPageViewModel(generatorContext: Generator
         .sortedBy { it.key }
         .map { ImageViewViewModel(it) }
 
-    val visible = diagrams.isNotEmpty() or images.isNotEmpty()
+    val hasProperties = container.includedProperties.isNotEmpty()
+    val propertiesTable = createPropertiesTableViewModel(container.includedProperties)
+    val visible = diagrams.isNotEmpty() or images.isNotEmpty() or hasProperties
     val containerTabs = createContainersComponentTabViewModel(generatorContext, container.softwareSystem)
     companion object {
         fun url(container: Container) = "${url(container.softwareSystem, Tab.COMPONENT)}/${container.name.normalize()}"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemContainerComponentsPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemContainerComponentsPage.kt
@@ -1,10 +1,8 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
-import kotlinx.html.HTML
-import kotlinx.html.div
-import kotlinx.html.li
-import kotlinx.html.ul
+import kotlinx.html.*
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemContainerComponentsPageViewModel
+import nl.avisi.structurizr.site.generatr.site.model.createPropertiesTableViewModel
 
 fun HTML.softwareSystemContainerComponentsPage(viewModel: SoftwareSystemContainerComponentsPageViewModel) {
      if (viewModel.visible) {
@@ -21,6 +19,11 @@ fun HTML.softwareSystemContainerComponentsPage(viewModel: SoftwareSystemContaine
             }
             viewModel.diagrams.forEach { diagram(it) }
             viewModel.images.forEach { image(it) }
+
+            if(viewModel.hasProperties) {
+                h6 { +"Properties" }
+                table(viewModel.propertiesTable)
+            }
         }
     } else
         redirectUpPage()

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/StructurizrUtilitiesTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/StructurizrUtilitiesTest.kt
@@ -1,0 +1,52 @@
+package nl.avisi.structurizr.site.generatr.site
+
+import com.structurizr.Workspace
+import nl.avisi.structurizr.site.generatr.includedProperties
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StructurizrUtilitiesTest {
+
+    protected val svgFactory = { _: String, _: String -> "" }
+
+    protected fun generatorContext(
+        workspaceName: String = "Workspace name",
+        branches: List<String> = listOf("main"),
+        currentBranch: String = "main",
+        version: String = "1.0.0"
+    ) = GeneratorContext(version, Workspace(workspaceName, ""), branches, currentBranch, false, svgFactory)
+
+    @Test
+    fun `includedProperties filters out structurizr and generatr properties`() {
+        val element = generatorContext().workspace.model.addSoftwareSystem("System 1")
+        element.addProperty("structurizr.key", "value")
+        element.addProperty("structurizrnotquite.key", "value")
+        element.addProperty("generatrbut.not.key", "value")
+        element.addProperty("other.key", "value")
+
+        val includedProperties = element.includedProperties
+
+        assertEquals(3, includedProperties.size)
+        assertEquals(includedProperties.keys, setOf("structurizrnotquite.key", "generatrbut.not.key", "other.key"))
+    }
+
+    @Test
+    fun `includedProperties returns all properties when none are filtered out`() {
+        val element = generatorContext().workspace.model.addSoftwareSystem("System 1")
+        element.addProperty("key1", "value1")
+        element.addProperty("key2", "value2")
+
+        val includedProperties = element.includedProperties
+
+        assertEquals(2, includedProperties.size)
+        assertEquals("key1", includedProperties.keys.first())
+        assertEquals("key2", includedProperties.keys.last())
+    }
+
+    @Test
+    fun `includedProperties returns empty map when no properties are set`() {
+        val element = generatorContext().workspace.model.addSoftwareSystem("System 1")
+        val includedProperties = element.includedProperties
+        assertEquals(0, includedProperties.size)
+    }
+}

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerComponentsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerComponentsPageViewModelTest.kt
@@ -1,15 +1,12 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
-import assertk.assertions.containsExactly
-import assertk.assertions.hasSize
-import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
-import assertk.assertions.isTrue
+import assertk.assertions.*
 import com.structurizr.model.Container
 import com.structurizr.model.SoftwareSystem
 import nl.avisi.structurizr.site.generatr.normalize
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class SoftwareSystemContainerComponentsPageViewModelTest : ViewModelTest() {
     private val generatorContext = generatorContext()
@@ -17,6 +14,9 @@ class SoftwareSystemContainerComponentsPageViewModelTest : ViewModelTest() {
         .addSoftwareSystem("Software system").also {
             val backend = it.addContainer("Backend")
             val frontend = it.addContainer("Frontend")
+            it.addContainer("Api").also { c ->
+                c.addProperty("test", "value")
+            }
             generatorContext.workspace.views.createComponentView(backend, "component-1-backend", "Component view 1 - Backend")
             generatorContext.workspace.views.createComponentView(backend, "component-2-backend", "Component view 2 - Backend")
 
@@ -26,6 +26,7 @@ class SoftwareSystemContainerComponentsPageViewModelTest : ViewModelTest() {
 
     private val backendContainer: Container = softwareSystem.containers.elementAt(0)
     private val frontendContainer: Container = softwareSystem.containers.elementAt(1)
+    private val apiContainer: Container = softwareSystem.containers.elementAt(2)
     private val backendImageView = createImageView(generatorContext.workspace, backendContainer)
     private val frontendImageView = createImageView(generatorContext.workspace, frontendContainer)
 
@@ -41,9 +42,11 @@ class SoftwareSystemContainerComponentsPageViewModelTest : ViewModelTest() {
         val viewModel = SoftwareSystemContainerComponentsPageViewModel(generatorContext, backendContainer)
         val componentTabList = listOf(
             ContainerTabViewModel(viewModel, "Backend", "/software-system/component/backend"),
-            ContainerTabViewModel(viewModel, "Frontend", "/software-system/component/frontend"))
-        assertThat(viewModel.containerTabs.elementAtOrNull(0)).isEqualTo(componentTabList.elementAt(0))
-        assertThat(viewModel.containerTabs.elementAtOrNull(1)).isEqualTo(componentTabList.elementAt(1))
+            ContainerTabViewModel(viewModel, "Frontend", "/software-system/component/frontend"),
+            ContainerTabViewModel(viewModel, "Api", "/software-system/component/api"))
+        assertThat(viewModel.containerTabs.elementAtOrNull(0)).isEqualTo(componentTabList.elementAt(2))
+        assertThat(viewModel.containerTabs.elementAtOrNull(1)).isEqualTo(componentTabList.elementAt(0))
+        assertThat(viewModel.containerTabs.elementAtOrNull(2)).isEqualTo(componentTabList.elementAt(1))
     }
 
     @Test
@@ -125,6 +128,15 @@ class SoftwareSystemContainerComponentsPageViewModelTest : ViewModelTest() {
         assertThat(viewModel.visible).isTrue()
         assertThat(viewModel.images).hasSize(1)
         assertThat(viewModel.images.single().imageView).isEqualTo(frontendImageView)
+    }
+
+    @Test
+    fun `has only properties`() {
+        val viewModel = SoftwareSystemContainerComponentsPageViewModel(generatorContext, apiContainer)
+        assertTrue(viewModel.visible)
+        assertThat(viewModel.propertiesTable.bodyRows).isNotEmpty()
+        assertThat(viewModel.images).isEmpty()
+        assertThat(viewModel.diagrams).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
Somewhat related to #611 

Shows any "custom" container properties on the container components page below any diagrams and image views.
Custom = not starting with `structurizr.` or `generatr.`

The container components page will be shown as long as the container has custom properties - even if it has no image views or diagrams

![image](https://github.com/user-attachments/assets/671035f8-0c35-4482-a76d-b0712dc6fe2c)


First time Kotlin user, so apologies in advance

