### PR TITLE
Sets ResourceHandler to not use filemapping, avoids win file locking

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/ServeCommand.kt
@@ -122,6 +122,7 @@ class ServeCommand : Subcommand("serve", "Start a development server") {
     private fun createStaticResourceHandler() =
         ResourceHandler().apply {
             baseResource = ResourceFactory.of(this).newResource(File(siteDir).absolutePath)
+            isUseFileMapping = false
         }
 
     private fun createWebSocketHandler(


### PR DESCRIPTION
After some digging (_older solutions_ involved e g `useFileMappedBuffer` or for `ResourceHandler` it was setting `setMinMemoryMappedContentLength` to -1, now deprecated) I found that after [this discussion](https://github.com/jetty/jetty.project/issues/10852), `ResourceHandler` got a flag for using file mapping in jetty version 12.0.5 ([jetty PR](https://github.com/jetty/jetty.project/pull/11071/files)). 

So, its a oneliner. Took a few hours to dig it up, TBH.

# Tested?
Yeah, on windows. Seems to work a charm. Sooo nice to not have it crash all the time. 

However, I dont have access to a mac here. Guessing it will be fine, but nice to check... ;-)