### PR TITLE
feat: enable parallel branch building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21.0.5_11-jre-jammy
 
 USER root
-RUN apt update && apt install graphviz --yes && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install graphviz git --yes && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/model \
     && chown 65532:65532 /var/model
 RUN useradd -d /home/generatr -u 65532 --create-home generatr

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     implementation("org.eclipse.jetty:jetty-server:12.0.15")
     implementation("org.eclipse.jetty.websocket:jetty-websocket-jetty-server:12.0.15")
 
+    implementation("org.apache.commons:commons-exec:1.4.0")
+
     runtimeOnly("org.slf4j:slf4j-simple:2.0.16")
     runtimeOnly("org.jetbrains.kotlin:kotlin-scripting-jsr223:2.0.21")
     runtimeOnly("org.codehaus.groovy:groovy-jsr223:3.0.23")


### PR DESCRIPTION
Hi,

One of the things that became an issue at some points is that building multiple branches with bigger model takes more and more time (our builds are getting to 40 mins). To solve this problem we would like to propose new flag `--parallel` in generate-site command that would use native git executable to establish `git worktree` for every branch that will be used and build those branches in parallel from separate branch git worktrees. jGit as of today doesn't have a support for worktrees - hence need to use native git executable. 

This should effectively make builds faster in most scenarios.

Any feedback mostly appreciated.