### PR TITLE
Allow to associate unscoped deployment views with a software system

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ architecture model:
 | `generatr.site.cdn`                     | Specifies the CDN base location for fetching NPM packages for browser runtime dependencies. Defaults to jsDelivr, but can be changed to e.g. an on-premise location.                                                                                                                                                                             | `https://cdn.jsdelivr.net/npm` | `https://cdn.my-company/npm`                         |
 | `generatr.site.theme`                   | Experimental: allows to force a light or dark theme or allows to switch between light and dark mode on the website with browser preference or menu item. Possible values are 'light', 'dark' or 'auto'. Note that the 'structurizr' exporter (see 'generatr.site.exporter' setting) generally works better for the dark theme.                   | `light`                        | `auto`                                               |
 
+To control the behavior of views, apply the following properties:
+
+| Property name                        | Description                                                                  | Value                | Scope           |
+|--------------------------------------|------------------------------------------------------------------------------|----------------------|-----------------|
+| `generatr.view.deployment.belongsTo` | Associate the diagram into the Deployment tab of a specific software system. | software system name | deployment view |
+
 See the included example for usage of some those properties in the
 [C4 architecture model example](https://github.com/avisi-cloud/structurizr-site-generatr/blob/main/docs/example/workspace.dsl#L163).
 

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -160,6 +160,24 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
 
             primaryDatabaseServer -> secondaryDatabaseServer "Replicates data to"
         }
+
+        deploymentEnvironment "Environment Landscape" {
+            deploymentNode "bigbank-prod001" {
+                softwareSystemInstance mainframe
+            }
+            deploymentNode "bigbank-preprod001" {
+                softwareSystemInstance mainframe
+            }
+            deploymentNode "bigbank-test001" {
+                softwareSystemInstance mainframe
+            }
+            deploymentNode "bigbank-staging1" {
+                softwareSystemInstance email
+            }
+            deploymentNode "bigbank-prod1" {
+                softwareSystemInstance email
+            }
+        }
     }
 
     views {
@@ -282,6 +300,14 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
                 liveSecondaryDatabaseInstance
             }
             autoLayout
+        }
+
+        deployment * "Environment Landscape" "EnvLandscapeMainframe" {
+            include mainframe
+            autoLayout
+            properties {
+                "generatr.view.deployment.belongsTo" "Mainframe Banking System"
+            }
         }
 
         styles {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/StructurizrUtilities.kt
@@ -65,5 +65,6 @@ fun ViewSet.hasCodeViews(workspace: Workspace, softwareSystem: SoftwareSystem) =
 fun ViewSet.hasDynamicViews(softwareSystem: SoftwareSystem) =
     dynamicViews.any { it.softwareSystem == softwareSystem }
 
-fun ViewSet.hasDeploymentViews(softwareSystem: SoftwareSystem) =
-    deploymentViews.any { it.softwareSystem == softwareSystem }
+fun ViewSet.hasDeploymentViews(softwareSystem: SoftwareSystem) = with(deploymentViews) {
+    any { it.softwareSystem == softwareSystem } || any { it.properties["generatr.view.deployment.belongsTo"] == softwareSystem.name }
+}

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModel.kt
@@ -7,7 +7,9 @@ import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 class SoftwareSystemDeploymentPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
     SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.DEPLOYMENT) {
     val diagrams = generatorContext.workspace.views.deploymentViews
-        .filter { it.softwareSystem == softwareSystem }
+        .filter {
+            it.softwareSystem == softwareSystem || it.properties["generatr.view.deployment.belongsTo"] == softwareSystem.name
+        }
         .map { DiagramViewModel.forView(this, it, generatorContext.svgFactory) }
     val visible = generatorContext.workspace.views.hasDeploymentViews(softwareSystem)
     val diagramIndex = DiagramIndexViewModel(diagrams)

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
@@ -1,10 +1,7 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import assertk.assertThat
-import assertk.assertions.containsExactly
-import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
-import assertk.assertions.isTrue
+import assertk.assertions.*
 import com.structurizr.model.SoftwareSystem
 import kotlin.test.Test
 
@@ -75,5 +72,21 @@ class SoftwareSystemDeploymentPageViewModelTest : ViewModelTest() {
     fun `has index`() {
         val viewModel = SoftwareSystemDeploymentPageViewModel(generatorContext, softwareSystem)
         assertThat(viewModel.diagramIndex.visible).isTrue()
+    }
+
+    @Test
+    fun `includes star-scoped deployment view when belongsTo in properties`() {
+        val viewModel = SoftwareSystemDeploymentPageViewModel(
+            generatorContext, generatorContext.workspace.model.addSoftwareSystem("Software system 3").also {
+                generatorContext.workspace.views.createDeploymentView("star-scoped", "Star Scoped Deployment View").apply {
+                    addProperty("generatr.view.deployment.belongsTo", it.name)
+                }
+            })
+
+        assertThat(viewModel.visible, "is visible").isTrue()
+
+        assertThat(viewModel.diagrams).exactly(1) { assert ->
+            assert.transform { it.key }.isEqualTo("star-scoped")
+        }
     }
 }


### PR DESCRIPTION
This introduces a new property `generatr.view.deployment.belongsTo` for deployment views. This property allows associating a "star-scoped" deployment view with a specific software system. This allows to show unscoped and filtered views within the context of a software system.

When creating deployment views which are unscoped (or "star-scoped"), there was no way to show the diagram on a software system's page due to the missing context. The diagram was just not visible anywhere.

By adding the new property it is now possible to have diagrams shown on the `Deployment views` tab of a software system.

Example deployment view:
```
views {
    deployment * environment Some-Filtered-View {
        autolayout
        include "element.parent==environment.cluster1"

        properties {
            "generatr.view.deployment.belongsTo" "Software System 1"
        }
    }
}
```