### PR TITLE
Feature/d2 format export

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation("com.structurizr:structurizr-core:3.2.1")
     implementation("com.structurizr:structurizr-dsl:3.2.1")
     implementation("com.structurizr:structurizr-export:3.2.1")
+    implementation("io.github.goto1134:structurizr-d2-exporter:1.5.0")
 
     implementation("net.sourceforge.plantuml:plantuml:1.2025.2")
 

--- a/docs/example/workspace.dsl
+++ b/docs/example/workspace.dsl
@@ -207,7 +207,7 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
             // default behaviour, if no generatr.markdown.flexmark.extensions property is specified, is to load the Tables extension only
             "generatr.markdown.flexmark.extensions" "Abbreviation,Admonition,AnchorLink,Attributes,Autolink,Definition,Emoji,Footnotes,GfmTaskList,GitLab,MediaTags,Tables,TableOfContents,Typographic"
 
-            "generatr.site.exporter" "structurizr"
+            "generatr.site.exporter" "d2"
             "generatr.site.externalTag" "External System"
             "generatr.site.nestGroups" "false"
             "generatr.site.cdn" "https://cdn.jsdelivr.net/npm"
@@ -227,12 +227,6 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
 
         systemcontext internetBankingSystem "SystemContext" {
             include *
-            animation {
-                internetBankingSystem
-                customer
-                mainframe
-                email
-            }
             autoLayout
             title "System Context of Internet Banking System"
             description "Describes the overall context"
@@ -240,25 +234,11 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
 
         container internetBankingSystem "Containers" {
             include *
-            animation {
-                customer mainframe email
-                webApplication
-                singlePageApplication
-                mobileApp
-                apiApplication
-                database
-            }
             autoLayout
         }
 
         component apiApplication "Components" {
             include *
-            animation {
-                singlePageApplication mobileApp database email mainframe
-                signinController securityComponent
-                accountsSummaryController mainframeBankingSystemFacade
-                resetPasswordController emailComponent
-            }
             autoLayout
         }
 
@@ -286,23 +266,11 @@ workspace "Big Bank plc" "This is an example workspace to illustrate the key fea
 
         deployment internetBankingSystem "Development" "DevelopmentDeployment" {
             include *
-            animation {
-                developerSinglePageApplicationInstance
-                developerWebApplicationInstance developerApiApplicationInstance
-                developerDatabaseInstance
-            }
             autoLayout
         }
 
         deployment internetBankingSystem "Live" "LiveDeployment" {
             include *
-            animation {
-                liveSinglePageApplicationInstance
-                liveMobileAppInstance
-                liveWebApplicationInstance liveApiApplicationInstance
-                livePrimaryDatabaseInstance
-                liveSecondaryDatabaseInstance
-            }
             autoLayout
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "structurizr-site-generatr",
     "dependencies": {
+        "@terrastruct/d2": "0.1.23",
         "bulma": "1.0.3",
         "katex": "0.16.21",
         "lunr": "2.3.9",

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/SiteGenerator.kt
@@ -1,8 +1,6 @@
 package nl.avisi.structurizr.site.generatr.site
 
 import com.structurizr.Workspace
-import com.structurizr.documentation.Documentation
-import com.structurizr.documentation.Section
 import com.structurizr.util.WorkspaceUtils
 import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
@@ -18,6 +16,7 @@ fun copySiteWideAssets(exportDir: File) {
     copySiteWideAsset(exportDir, "/css/style.css")
     copySiteWideAsset(exportDir, "/js/header.js")
     copySiteWideAsset(exportDir, "/js/svg-modal.js")
+    copySiteWideAsset(exportDir, "/js/d2-to-svg.js")
     copySiteWideAsset(exportDir, "/js/modal.js")
     copySiteWideAsset(exportDir, "/js/search.js")
     copySiteWideAsset(exportDir, "/js/auto-reload.js")

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/DiagramViewModel.kt
@@ -1,16 +1,20 @@
 package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.view.View
+import nl.avisi.structurizr.site.generatr.site.ExporterType
+import nl.avisi.structurizr.site.generatr.site.exporterType
 
 data class DiagramViewModel(
     val key: String,
     val title: String,
     val description: String?,
     val svg: String?,
+    val type: ExporterType,
     val diagramWidthInPixels: Int?,
     val svgLocation: ImageViewModel,
     val pngLocation: ImageViewModel,
-    val pumlLocation: ImageViewModel
+    val pumlLocation: ImageViewModel,
+    val d2Localtion: ImageViewModel,
 ) {
     companion object {
         fun forView(pageViewModel: PageViewModel, view: View, svgFactory: (key: String, url: String) -> String?) =
@@ -30,10 +34,12 @@ data class DiagramViewModel(
                 title ?: name,
                 description,
                 svg,
-                extractDiagramWidthInPixels(svg),
+                pageViewModel.generatorContext.workspace.exporterType(),
+                extractDiagramWidthInPixels(if (pageViewModel.generatorContext.workspace.exporterType() == ExporterType.D2) null else svg),
                 ImageViewModel(pageViewModel, "/svg/$key.svg"),
                 ImageViewModel(pageViewModel, "/png/$key.png"),
-                ImageViewModel(pageViewModel, "/puml/$key.puml")
+                ImageViewModel(pageViewModel, "/puml/$key.puml"),
+                ImageViewModel(pageViewModel, "/d2/$key.d2")
             )
         }
 

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/PageViewModel.kt
@@ -4,7 +4,7 @@ import nl.avisi.structurizr.site.generatr.includedSoftwareSystems
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 import nl.avisi.structurizr.site.generatr.site.views.CDN
 
-abstract class PageViewModel(protected val generatorContext: GeneratorContext) {
+abstract class PageViewModel(val generatorContext: GeneratorContext) {
     val pageTitle: String by lazy {
         if (pageSubTitle.isNotBlank() && generatorContext.workspace.name.isNotBlank())
             "$pageSubTitle | ${generatorContext.workspace.name}"

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/CDN.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/CDN.kt
@@ -23,6 +23,10 @@ class CDN(val workspace: Workspace) {
         "${it.baseUrl()}/css/bulma.min.css"
     }
 
+    fun d2Js() = dependencies.single { it.name == "@terrastruct/d2" }.let {
+        "${it.baseUrl()}/dist/browser/index.min.js"
+    }
+
     fun katexJs() = dependencies.single { it.name == "katex" }.let {
         "${it.baseUrl()}/dist/katex.min.js"
     }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Diagram.kt
@@ -1,9 +1,17 @@
 package nl.avisi.structurizr.site.generatr.site.views
 
 import kotlinx.html.*
+import nl.avisi.structurizr.site.generatr.site.ExporterType
 import nl.avisi.structurizr.site.generatr.site.model.DiagramViewModel
 
 fun FlowContent.diagram(viewModel: DiagramViewModel) {
+    when (viewModel.type) {
+        ExporterType.C4, ExporterType.STRUCTURIZR -> this.addSvg(viewModel)
+        ExporterType.D2 -> this.addD2(viewModel)
+    }
+}
+
+private fun FlowContent.addSvg(viewModel: DiagramViewModel) {
     if (viewModel.svg != null) {
         val dialogId = "${viewModel.key}-modal"
         val svgId = "${viewModel.key}-svg"
@@ -24,7 +32,6 @@ fun FlowContent.diagram(viewModel: DiagramViewModel) {
             }
         }
         modal(dialogId) {
-            // TODO: no links in this SVG
             rawHtml(viewModel.svg, svgId, "modal-box-content")
             div(classes = "has-text-centered") {
                 +viewModel.title
@@ -37,10 +44,38 @@ fun FlowContent.diagram(viewModel: DiagramViewModel) {
                 +"]"
             }
         }
-    } else
+    } else {
         div(classes = "notification is-danger") {
             +"No view with key"
             span(classes = "has-text-weight-bold") { +" ${viewModel.key} " }
             +"found!"
         }
+    }
+}
+
+private fun FlowContent.addD2(viewModel: DiagramViewModel) {
+    val dialogId = "${viewModel.key}-modal"
+    val svgId = "${viewModel.key}-svg"
+
+    figure {
+        style = "width: min(100%, ${viewModel.diagramWidthInPixels}px);"
+        attributes["id"] = viewModel.key
+
+        pre {
+            classes = setOf("d2")
+            if (viewModel.svg != null) attributes["page"] = viewModel.svg
+            +"Generating figure..."
+        }
+
+        figcaption {
+            a {
+                onClick = "openSvgModal('$dialogId', '$svgId')"
+                +viewModel.title
+                if (!viewModel.description.isNullOrBlank()) {
+                    br
+                    +viewModel.description
+                }
+            }
+        }
+    }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/MarkdownExtension.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/MarkdownExtension.kt
@@ -27,6 +27,16 @@ fun HEAD.katexStylesheet(cdn: CDN) {
     }
 }
 
+fun HEAD.d2Script(viewModel: PageViewModel) {
+    script(type = "module") {
+        unsafe {
+            raw("import { D2 } from '${viewModel.cdn.d2Js()}'; window.D2 = D2;")
+        }
+    }
+    script(type = "module", src = "../" + "/d2-to-svg.js".asUrlToFile(viewModel.url)) { }
+//    script(type = ScriptType.textJavaScript, src = "../" + "/d2-to-svg.js".asUrlToFile(viewModel.url)) { }
+}
+
 fun HEAD.katexScript(cdn: CDN) {
     // loading KaTeX as global on a webpage: https://katex.org/docs/browser.html#loading-as-global
     unsafe {

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/Page.kt
@@ -31,6 +31,7 @@ private fun HTML.headFragment(viewModel: PageViewModel) {
         link(rel = "stylesheet", href = "./" + "/style-branding.css".asUrlToFile(viewModel.url))
         script(type = ScriptType.textJavaScript, src = "../" + "/modal.js".asUrlToFile(viewModel.url)) { }
         script(type = ScriptType.textJavaScript, src = "../" + "/svg-modal.js".asUrlToFile(viewModel.url)) { }
+        d2Script(viewModel)
         script(type = ScriptType.textJavaScript, src = viewModel.cdn.svgpanzoomJs()) { }
         if (viewModel.allowToggleTheme)
             script(type = ScriptType.textJavaScript, src = "../" + "/toggle-theme.js".asUrlToFile(viewModel.url)) { }

--- a/src/main/resources/assets/js/d2-to-svg.js
+++ b/src/main/resources/assets/js/d2-to-svg.js
@@ -1,0 +1,43 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const divElements = document.querySelectorAll("pre");
+    let d2 = new window.D2();
+    for (const div of divElements) {
+        const d2Text = div.getAttribute("page");
+        try {
+            const compiled = await d2.compile(d2Text, {
+                layout: "dagre",
+                sketch: false,
+                themeId: null,
+                darkThemeId: null,
+                scale: 1,
+                pad: 50,
+                center: true,
+                forceAppendix: null,
+                target: null,
+                animateInterval: null,
+                salt: null,
+                fontRegular: null,
+                fontItalic: null,
+                fontSemibold: null,
+                fontBold: null,
+                noXmlTag: true,
+            });
+            const svgString = await d2.render(compiled.diagram, compiled.renderOptions);
+
+            const parser = new DOMParser();
+            const svgDoc = parser.parseFromString(svgString, "image/svg+xml");
+            const svg = svgDoc.documentElement;
+
+            svg.setAttribute("width", "100%");
+            svg.setAttribute("height", "auto");
+            svg.style.maxWidth = "100%";
+            svg.style.height = "auto";
+            div.innerHTML = "";
+            div.appendChild(svg);
+            div.parentElement.style.maxWidth = "800px";
+        } catch (err) {
+            console.error("D2 rendering failed:", err);
+            pre.innerHTML = `<span style="color: red;">Failed to render D2 diagram: ${err.message}</span>`;
+        }
+    }
+});

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerComponentsPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerComponentsPageViewModelTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.*
 import com.structurizr.model.Container
 import com.structurizr.model.SoftwareSystem
 import nl.avisi.structurizr.site.generatr.normalize
+import nl.avisi.structurizr.site.generatr.site.exporterType
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -74,20 +75,24 @@ class SoftwareSystemContainerComponentsPageViewModelTest : ViewModelTest() {
                 "Software system - Backend - Components",
                 "Component view 1 - Backend",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/component-1-backend.svg"),
                 ImageViewModel(viewModel, "/png/component-1-backend.png"),
-                ImageViewModel(viewModel, "/puml/component-1-backend.puml")
+                ImageViewModel(viewModel, "/puml/component-1-backend.puml"),
+                ImageViewModel(viewModel, "/d2/component-1-backend.d2")
             ),
             DiagramViewModel(
                 "component-2-backend",
                 "Software system - Backend - Components",
                 "Component view 2 - Backend",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/component-2-backend.svg"),
                 ImageViewModel(viewModel, "/png/component-2-backend.png"),
-                ImageViewModel(viewModel, "/puml/component-2-backend.puml")
+                ImageViewModel(viewModel, "/puml/component-2-backend.puml"),
+                ImageViewModel(viewModel, "/d2/component-2-backend.d2")
             )
         )
 
@@ -99,20 +104,24 @@ class SoftwareSystemContainerComponentsPageViewModelTest : ViewModelTest() {
                 "Software system - Frontend - Components",
                 "Component view 1 - Frontend",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/component-1-frontend.svg"),
                 ImageViewModel(viewModel, "/png/component-1-frontend.png"),
-                ImageViewModel(viewModel, "/puml/component-1-frontend.puml")
+                ImageViewModel(viewModel, "/puml/component-1-frontend.puml"),
+                ImageViewModel(viewModel, "/d2/component-1-frontend.d2")
             ),
             DiagramViewModel(
                 "component-2-frontend",
                 "Software system - Frontend - Components",
                 "Component view 2 - Frontend",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/component-2-frontend.svg"),
                 ImageViewModel(viewModel, "/png/component-2-frontend.png"),
-                ImageViewModel(viewModel, "/puml/component-2-frontend.puml")
+                ImageViewModel(viewModel, "/puml/component-2-frontend.puml"),
+                ImageViewModel(viewModel, "/d2/component-2-frontend.d2")
             )
         )
     }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerPageViewModelTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.site.exporterType
 import kotlin.test.Test
 
 class SoftwareSystemContainerPageViewModelTest : ViewModelTest() {
@@ -37,20 +38,24 @@ class SoftwareSystemContainerPageViewModelTest : ViewModelTest() {
                 "Software system - Containers",
                 "Container view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/container-1.svg"),
                 ImageViewModel(viewModel, "/png/container-1.png"),
-                ImageViewModel(viewModel, "/puml/container-1.puml")
+                ImageViewModel(viewModel, "/puml/container-1.puml"),
+                ImageViewModel(viewModel, "/d2/container-1.d2")
             ),
             DiagramViewModel(
                 "container-2",
                 "Software system - Containers",
                 "Container view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/container-2.svg"),
                 ImageViewModel(viewModel, "/png/container-2.png"),
-                ImageViewModel(viewModel, "/puml/container-2.puml")
+                ImageViewModel(viewModel, "/puml/container-2.puml"),
+                ImageViewModel(viewModel, "/d2/container-2.d2")
             )
         )
     }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContextPageViewModelTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.containsExactly
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.site.exporterType
 import kotlin.test.Test
 
 class SoftwareSystemContextPageViewModelTest : ViewModelTest() {
@@ -25,20 +26,24 @@ class SoftwareSystemContextPageViewModelTest : ViewModelTest() {
                 "Software system - System Context",
                 "System context view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/context-1.svg"),
                 ImageViewModel(viewModel, "/png/context-1.png"),
-                ImageViewModel(viewModel, "/puml/context-1.puml")
+                ImageViewModel(viewModel, "/puml/context-1.puml"),
+                ImageViewModel(viewModel, "/d2/context-1.d2")
             ),
             DiagramViewModel(
                 "context-2",
                 "Software system - System Context",
                 "System context view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/context-2.svg"),
                 ImageViewModel(viewModel, "/png/context-2.png"),
-                ImageViewModel(viewModel, "/puml/context-2.puml")
+                ImageViewModel(viewModel, "/puml/context-2.puml"),
+                ImageViewModel(viewModel, "/d2/context-2.d2")
             )
         )
     }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDeploymentPageViewModelTest.kt
@@ -3,6 +3,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 import assertk.assertThat
 import assertk.assertions.*
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.site.exporterType
 import kotlin.test.Test
 
 class SoftwareSystemDeploymentPageViewModelTest : ViewModelTest() {
@@ -31,20 +32,23 @@ class SoftwareSystemDeploymentPageViewModelTest : ViewModelTest() {
                 "Software system - Deployment - Default",
                 "Deployment view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/deployment-1.svg"),
                 ImageViewModel(viewModel, "/png/deployment-1.png"),
-                ImageViewModel(viewModel, "/puml/deployment-1.puml")
-            ),
+                ImageViewModel(viewModel, "/puml/deployment-1.puml"),
+                ImageViewModel(viewModel, "/d2/deployment-1.d2")),
             DiagramViewModel(
                 "deployment-2",
                 "Software system - Deployment - Default",
                 "Deployment view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/deployment-2.svg"),
                 ImageViewModel(viewModel, "/png/deployment-2.png"),
-                ImageViewModel(viewModel, "/puml/deployment-2.puml")
+                ImageViewModel(viewModel, "/puml/deployment-2.puml"),
+                ImageViewModel(viewModel, "/d2/deployment-2.d2")
             )
         )
     }

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDynamicPageViewModelTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemDynamicPageViewModelTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import com.structurizr.model.SoftwareSystem
+import nl.avisi.structurizr.site.generatr.site.exporterType
 import kotlin.test.Test
 
 class SoftwareSystemDynamicPageViewModelTest : ViewModelTest() {
@@ -36,20 +37,24 @@ class SoftwareSystemDynamicPageViewModelTest : ViewModelTest() {
                 "Backend - Dynamic",
                 "Dynamic view 1",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/backend-dynamic.svg"),
                 ImageViewModel(viewModel, "/png/backend-dynamic.png"),
-                ImageViewModel(viewModel, "/puml/backend-dynamic.puml")
+                ImageViewModel(viewModel, "/puml/backend-dynamic.puml"),
+                ImageViewModel(viewModel, "/d2/backend-dynamic.d2")
             ),
             DiagramViewModel(
                 "frontend-dynamic",
                 "Frontend - Dynamic",
                 "Dynamic view 2",
                 """<svg viewBox="0 0 800 900"></svg>""",
+                generatorContext.workspace.exporterType(),
                 800,
                 ImageViewModel(viewModel, "/svg/frontend-dynamic.svg"),
                 ImageViewModel(viewModel, "/png/frontend-dynamic.png"),
-                ImageViewModel(viewModel, "/puml/frontend-dynamic.puml")
+                ImageViewModel(viewModel, "/puml/frontend-dynamic.puml"),
+                ImageViewModel(viewModel, "/d2/frontend-dynamic.d2")
             )
         )
     }


### PR DESCRIPTION
Tot nu toe zijn er 2 standaard export types (C4 & Sturcturizr). Ik heb daar een derde aan toegevoegd: D2 exporter. Deze is beskchikbaar van [deze repo](https://github.com/goto1134/structurizr-d2-exporter/). Nu kan er "d2" worden opgegeven bij de view properties voor de generatr.