### PR TITLE
Add redirection to documentation sections

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SectionsTableViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SectionsTableViewModel.kt
@@ -41,7 +41,7 @@ fun BaseSoftwareSystemSectionsPageViewModel.createSectionsTabViewModel(
     tab: SoftwareSystemPageViewModel.Tab,
     linkMatch: (StaticStructureElement) -> Match = { Match.EXACT }
 ) = buildList {
-    if (softwareSystem.hasDocumentationSections(recursive = true)) {
+    if (softwareSystem.hasDocumentationSections()) {
         add(
             SectionTabViewModel(
                 this@createSectionsTabViewModel,

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionsPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemContainerSectionsPageViewModel.kt
@@ -3,14 +3,20 @@ package nl.avisi.structurizr.site.generatr.site.model
 import com.structurizr.documentation.Section
 import com.structurizr.model.Component
 import com.structurizr.model.Container
+import nl.avisi.structurizr.site.generatr.hasComponentsSections
 import nl.avisi.structurizr.site.generatr.hasSections
 import nl.avisi.structurizr.site.generatr.normalize
 import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 
 abstract class BaseSoftwareSystemContainerSectionsPageViewModel(generatorContext: GeneratorContext, container: Container) :
     BaseSoftwareSystemSectionsPageViewModel(generatorContext, container.softwareSystem) {
+    private val componentsDocumentationSectionsVisible = container.hasComponentsSections()
 
-    override val visible = container.hasSections(recursive = true)
+    override val containerDocumentationSectionsVisible = container.hasSections()
+
+    val onlyComponentsDocumentationSectionsVisible = !containerDocumentationSectionsVisible and componentsDocumentationSectionsVisible
+
+    override val visible = containerDocumentationSectionsVisible or componentsDocumentationSectionsVisible
 
     val sectionsTable: TableViewModel = createSectionsTableViewModel(container.documentation.sections, dropFirst = false) {
         sectionTableItemUrl(container, it)
@@ -19,14 +25,16 @@ abstract class BaseSoftwareSystemContainerSectionsPageViewModel(generatorContext
     val componentSectionsTabs by lazy {
         val components = container.components.filter { it.hasSections() }
         buildList(components.size) {
-            add(
-                SectionTabViewModel(
-                    this@BaseSoftwareSystemContainerSectionsPageViewModel,
-                    "Container",
-                    sectionTableItemUrl(container),
-                    Match.EXACT
+            if (container.hasSections()) {
+                add(
+                    SectionTabViewModel(
+                        this@BaseSoftwareSystemContainerSectionsPageViewModel,
+                        "Container",
+                        sectionTableItemUrl(container),
+                        Match.EXACT
+                    )
                 )
-            )
+            }
 
             addAll(
                 components.map { component ->

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModel.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/model/SoftwareSystemSectionsPageViewModel.kt
@@ -2,7 +2,7 @@ package nl.avisi.structurizr.site.generatr.site.model
 
 import com.structurizr.model.Container
 import com.structurizr.model.SoftwareSystem
-import nl.avisi.structurizr.site.generatr.hasComponentDocumentationSections
+import nl.avisi.structurizr.site.generatr.hasContainerDecisions
 import nl.avisi.structurizr.site.generatr.hasContainerDocumentationSections
 import nl.avisi.structurizr.site.generatr.hasDocumentationSections
 import nl.avisi.structurizr.site.generatr.normalize
@@ -11,16 +11,24 @@ import nl.avisi.structurizr.site.generatr.site.GeneratorContext
 abstract class BaseSoftwareSystemSectionsPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
     SoftwareSystemPageViewModel(generatorContext, softwareSystem, Tab.SECTIONS) {
 
-    open val visible = softwareSystem.hasDocumentationSections(recursive = true)
+    protected open val containerDocumentationSectionsVisible = softwareSystem.hasContainerDocumentationSections(recursive = true)
+    private val softwareSystemDocumentationSectionsVisible = softwareSystem.hasDocumentationSections()
+
+    open val visible = softwareSystemDocumentationSectionsVisible or containerDocumentationSectionsVisible
+    val onlyContainersDocumentationSectionsVisible = !softwareSystemDocumentationSectionsVisible and containerDocumentationSectionsVisible
 
     val sectionsTabs: List<SectionTabViewModel> = createSectionsTabViewModel(softwareSystem, Tab.SECTIONS) {
         if (it is Container) Match.CHILD else Match.EXACT
     }
 }
 
-class SoftwareSystemSectionsPageViewModel(generatorContext: GeneratorContext, softwareSystem: SoftwareSystem) :
-    BaseSoftwareSystemSectionsPageViewModel(generatorContext, softwareSystem) {
-
+class SoftwareSystemSectionsPageViewModel(
+    generatorContext: GeneratorContext,
+    softwareSystem: SoftwareSystem
+) : BaseSoftwareSystemSectionsPageViewModel(
+    generatorContext,
+    softwareSystem
+) {
     val sectionsTable = createSectionsTableViewModel(softwareSystem.documentation.sections) {
         "$url/${it.contentTitle().normalize()}"
     }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemContainerSectionsPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemContainerSectionsPage.kt
@@ -5,7 +5,11 @@ import nl.avisi.structurizr.site.generatr.site.model.BaseSoftwareSystemContainer
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemContainerSectionsPageViewModel
 
 fun HTML.softwareSystemContainerSectionsPage(viewModel: SoftwareSystemContainerSectionsPageViewModel) {
-    if (viewModel.visible)
+    if (viewModel.onlyComponentsDocumentationSectionsVisible)
+        redirectRelative(
+            viewModel.componentSectionsTabs.first().link.relativeHref
+        )
+    else if (viewModel.visible)
         softwareSystemPage(viewModel) {
             softwareSystemContainerSectionsBody(viewModel)
             table(viewModel.sectionsTable)

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionsPage.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/views/SoftwareSystemSectionsPage.kt
@@ -5,7 +5,11 @@ import nl.avisi.structurizr.site.generatr.site.model.BaseSoftwareSystemSectionsP
 import nl.avisi.structurizr.site.generatr.site.model.SoftwareSystemSectionsPageViewModel
 
 fun HTML.softwareSystemSectionsPage(viewModel: SoftwareSystemSectionsPageViewModel) {
-    if (viewModel.visible)
+    if (viewModel.onlyContainersDocumentationSectionsVisible) {
+        redirectRelative(
+            viewModel.sectionsTabs.first().link.relativeHref
+        )
+    } else if (viewModel.visible)
         softwareSystemPage(viewModel) {
             softwareSystemSectionsBody(viewModel)
             table(viewModel.sectionsTable)


### PR DESCRIPTION
This adds redirections to documentation sections. This results in the following behavior:

- When a software system doesn't have documentation sections but a container does it will redirect to the first container's documentation sections.
- When a container doesn't have documentation sections but a component does it will redirect to the first component's documentation sections.