### PR TITLE
fix(mermaid): don't re-parse diagram text as HTML (fixes "Syntax error in text")

### DIFF
--- a/src/main/resources/assets/js/reformat-mermaid.js
+++ b/src/main/resources/assets/js/reformat-mermaid.js
@@ -1,17 +1,29 @@
-// solution from https://css-tricks.com/making-mermaid-diagrams-in-markdown/
-
-// select <pre class="mermaid"> _and_ <pre><code class="language-mermaid">
+// Put the Mermaid contents in the expected <div class="mermaid">, and keep the
+// original source in a <details> block.
+//
+// Adapted from https://css-tricks.com/making-mermaid-diagrams-in-markdown/, but
+// deliberately NOT via `outerHTML`: assigning the diagram text into an HTML string
+// makes the browser re-parse it as HTML. Angle-bracket placeholders that are common
+// in sequence diagrams (`<pub>`, `<IP>`, `<tempfile>`, ...) then become real DOM
+// elements, Mermaid receives mangled text and renders "Syntax error in text".
+// Building the nodes and assigning via textContent keeps the diagram source intact.
 document.querySelectorAll("pre.mermaid, pre>code.language-mermaid, div.mermaid").forEach($el => {
-    // if the second selector got a hit, reference the parent <pre>
-    if ($el.tagName === "CODE")
-      $el = $el.parentElement
-    // put the Mermaid contents in the expected <div class="mermaid">
-    // plus keep the original contents in a nice <details>
-    $el.outerHTML = `
-      <div class="mermaid">${$el.textContent}</div>
-      <details>
-        <summary>Diagram source</summary>
-        <pre>${$el.textContent}</pre>
-      </details>
-    `
-  })
+  // if the second selector got a hit, reference the parent <pre>
+  if ($el.tagName === "CODE")
+    $el = $el.parentElement
+
+  const source = $el.textContent
+
+  const diagram = document.createElement("div")
+  diagram.className = "mermaid"
+  diagram.textContent = source
+
+  const details = document.createElement("details")
+  const summary = document.createElement("summary")
+  summary.textContent = "Diagram source"
+  const pre = document.createElement("pre")
+  pre.textContent = source
+  details.append(summary, pre)
+
+  $el.replaceWith(diagram, details)
+})


### PR DESCRIPTION
Fixes #825.

`reformat-mermaid.js` assigned the diagram text back via `outerHTML`, which makes the browser **re-parse that string as HTML**. Angle-bracket placeholders that are common in sequence diagrams — `<pub>`, `<IP>`, `<tempfile>` — then become real DOM elements, Mermaid receives mangled text, and the diagram renders as **"Syntax error in text"**. The Mermaid source itself is valid.

This builds the nodes and sets their content via `textContent` instead, so no HTML re-parse happens and the diagram source reaches Mermaid unchanged. Behaviour is otherwise identical, including the `<details>Diagram source</details>` block.

### Verification

Against a real generated site (jsdom, running the actual asset, following Mermaid's `innerHTML` + entity-decode path), for a page with one `classDiagram` and three `sequenceDiagram`s containing `<pub>` / `<IP>` / `<tempfile>`:

| | child elements in `div.mermaid` | `mermaid.parse()` |
|---|---|---|
| before (`outerHTML`) | 1 — `<pub>` became a `<PUB>` element | **Parse error** |
| after (`textContent`) | 0 | **OK** |

Before the fix the line

```
API->>WG: wg set wg0 peer <pub> allowed-ips <IP>/32
```

reached Mermaid as `... peer  allowed-ips /32`, with the surrounding structure broken. After the fix it arrives verbatim, and all three sequence diagrams parse cleanly.

Diagrams without angle brackets (e.g. `classDiagram`) were unaffected either way, which is why this went unnoticed.

### Notes

- No Kotlin/Gradle changes — this only touches the static site asset, so there is no unit test to extend.
- I kept the `<details>Diagram source</details>` output byte-for-byte equivalent, and left a comment explaining *why* `outerHTML` must not be reintroduced.

Thanks again for the tool — happy to adjust the approach if you'd prefer a different shape.
