### PR TITLE
feat(diagrams): render an element's model url as a link

### DIFF
--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/CreateStructurizrWorkspace.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/CreateStructurizrWorkspace.kt
@@ -5,6 +5,13 @@ import com.structurizr.model.Element
 import com.structurizr.view.ThemeUtils
 import java.io.File
 
+/**
+ * The url an element defines in the model is moved here, because the url field itself is
+ * used to carry the generated drill-down links. Read it from this property to render the
+ * element's own link.
+ */
+const val ORIGINAL_URL_PROPERTY = "Url"
+
 fun createStructurizrWorkspace(workspaceFile: File) =
     StructurizrDslParser()
         .apply { parse(workspaceFile) }
@@ -19,7 +26,7 @@ fun createStructurizrWorkspace(workspaceFile: File) =
 
 private fun moveUrlToProperty(element: Element) {
     if (element.url != null) {
-        element.addProperty("Url", element.url)
+        element.addProperty(ORIGINAL_URL_PROPERTY, element.url)
         element.url = null
     }
 }

--- a/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/PlantUmlExporter.kt
+++ b/src/main/kotlin/nl/avisi/structurizr/site/generatr/site/PlantUmlExporter.kt
@@ -83,7 +83,12 @@ private class WriterWithElementLinks(
             needsLinkToContainerViews(element, view, workspace) -> getUrlToElement(element)
             needsLinkToComponentViews(element, view, workspace) -> getUrlToElement(element)
             needsLinkToCodeViews(element, workspace) -> getUrlToElement(element)
-            else -> null
+            // No view to drill into. Fall back to the URL the model defines, so a person
+            // can link to its persona, or a leaf container to its ADR. createStructurizrWorkspace
+            // moves that URL into the "Url" property (the url field itself is needed for the
+            // drill-down links above), so read it from there. Drill-down links keep
+            // precedence, so existing behaviour is unchanged.
+            else -> element?.properties?.get(ORIGINAL_URL_PROPERTY)?.takeIf { it.isNotBlank() }
         }
 
         if (url != null)

--- a/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/PlantUmlExporterTest.kt
+++ b/src/test/kotlin/nl/avisi/structurizr/site/generatr/site/PlantUmlExporterTest.kt
@@ -2,13 +2,19 @@ package nl.avisi.structurizr.site.generatr.site
 
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
 import com.structurizr.Workspace
+import nl.avisi.structurizr.site.generatr.ORIGINAL_URL_PROPERTY
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import kotlin.test.Test
 
 class PlantUmlExporterTest {
+    private companion object {
+        const val ELEMENT_URL = "https://example.com/personas#felix"
+    }
+
     @TestFactory
     fun `adds skinparam to remove explicit size from generated svg`() = exporters().map { (type, exporterFn) ->
         DynamicTest.dynamicTest("($type)") {
@@ -371,6 +377,50 @@ class PlantUmlExporterTest {
             System2 --> System1 <<Relationship-UmVsYXRpb25zaGlw>> : "uses"
             """.trimIndent()
         )
+    }
+
+    @TestFactory
+    fun `renders the url defined on an element when there is no view to drill into`() =
+        exporters().map { (type, exporterFn) ->
+            DynamicTest.dynamicTest("($type)") {
+                val workspace = createWorkspaceWithPersonWithUrl()
+
+                val diagram = exporterFn(workspace, "/system-1/context/")
+                    .export(workspace.views.systemContextViews.first())
+
+                assertThat(diagram.definition).contains(ELEMENT_URL)
+            }
+        }
+
+    @TestFactory
+    fun `prefers the drill-down link over the url defined on an element`() =
+        exporters().map { (type, exporterFn) ->
+            DynamicTest.dynamicTest("($type)") {
+                val workspace = createWorkspaceWithOneSystemWithContainers()
+                val system = workspace.model.getSoftwareSystemWithName("System 1")!!
+                system.addProperty(ORIGINAL_URL_PROPERTY, ELEMENT_URL)
+
+                val diagram = exporterFn(workspace, "/container/")
+                    .export(workspace.views.systemContextViews.first())
+
+                assertThat(diagram.definition).contains("../system-1/container/")
+                assertThat(diagram.definition).doesNotContain(ELEMENT_URL)
+            }
+        }
+
+    private fun createWorkspaceWithPersonWithUrl(): Workspace {
+        val workspace = Workspace("workspace name", "")
+        val system = workspace.model.addSoftwareSystem("System 1")
+        val person = workspace.model.addPerson("Admin")
+        // createStructurizrWorkspace moves an element's url into this property,
+        // because the url field itself carries the generated drill-down links.
+        person.addProperty(ORIGINAL_URL_PROPERTY, ELEMENT_URL)
+        person.uses(system, "Uses")
+
+        workspace.views.createSystemContextView(system, "Context1", "")
+            .apply { addAllElements() }
+
+        return workspace
     }
 
     private fun createWorkspaceWithOneSystem(): Workspace {


### PR DESCRIPTION
Fixes #827.

**Note:** the first version of this PR was based on a wrong reading of the code and has been replaced. See the correction in #827 — the short version is that the URL is *not* lost, it is deliberately preserved, and this PR now reads it back from where you already put it.

### The gap

`createStructurizrWorkspace` moves an element's `url` into a `"Url"` property:

```kotlin
private fun moveUrlToProperty(element: Element) {
    if (element.url != null) {
        element.addProperty("Url", element.url)   // We need the URL later for our own links,
        element.url = null                        // preserve the original in a property
    }
}
```

That is exactly right: the `url` field itself has to carry the generated drill-down links, so the model's own URL is parked in a property. But **it is never read back**. An element with no view to drill into — a person, an external system, a leaf container — is written without any link at all, whatever the model says.

So the intent is already in the codebase (the comment says "we need the URL later"); only the last step is missing.

### The change

```kotlin
val url = when {
    needsLinkToSoftwareSystem(element, view) -> getUrlToElement(element, "context")
    needsLinkToContainerViews(element, view, workspace) -> getUrlToElement(element)
    needsLinkToComponentViews(element, view, workspace) -> getUrlToElement(element)
    needsLinkToCodeViews(element, workspace) -> getUrlToElement(element)
-   else -> null
+   else -> element?.properties?.get(ORIGINAL_URL_PROPERTY)?.takeIf { it.isNotBlank() }
}
```

The property name becomes a shared constant next to `moveUrlToProperty`, so the two sides cannot drift apart.

**Drill-down links keep precedence**, so nothing that has a link today changes. The feature is purely additive: elements that previously got *no* link now get the one the model defines.

### Why it matters

The generatr already renders documentation and decisions as first-class pages, but a diagram cannot reach them. With this, the link is declarative and lives in the model:

```
admin = person "Admin" "Manages peers, users, roles and ACLs." {
    url "https://example.com/architecture/master/product-requirements/#persona-felix"
}
```

Person → persona, container → its ADR or arc42 chapter.

### Verified in production

Running on a real published site ([islandr-gateway.net/architecture](https://islandr-gateway.net/architecture/master/islandr/context/)): clicking the **Admin** or **End User** actor in the context and container views now jumps to that persona in the product requirements page. Both link kinds coexist on the same diagram — the software system still drills down to its container view.

Before this, the same effect needed ~70 lines of client-side JavaScript that wrapped the person elements by matching `data-qualified-name` — and had to match *exactly*, or it would link `AdminConsole` (a container) and `AdminBrowser` (an infrastructure node) to a persona too. That JS is now deleted. The model has no such ambiguity.

### Tests

Two new cases in `PlantUmlExporterTest`, each run against both exporters via the existing `exporters()` factory:

- `renders the url defined on an element when there is no view to drill into`
- `prefers the drill-down link over the url defined on an element` — pins the precedence, so the additive guarantee is enforced

They set the `"Url"` property, which is what `createStructurizrWorkspace` does — an earlier version set `element.url` directly, which passed while the real pipeline still did nothing. Full suite green locally (`./gradlew test`, Temurin 21).

### Note

`TEMP_URI` rewriting is unaffected: an absolute model URL contains no `TEMP_URI` and passes through untouched. The existing `generatr.svglink.target` property applies to these links for free.

One thing I did *not* decide: when an element has both a drill-down target and a `url`, the drill-down wins. That is the backwards-compatible choice, but surfacing both would be a UI decision that belongs to you.
